### PR TITLE
08/02 updates: Bug fixes, defensive checks, grammar updates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -241,7 +241,8 @@ module.exports = function(grunt) {
           //console.log(basedOn.namespace + " / " + basedOn.label);
           createFieldList(concreteDataelement, basedOn.namespace, namespaces[basedOn.namespace].index[basedOn.label]);
         } else if (basedOn.type === "TBD") {
-          console.log("The basedOn Element %s has yet to be defined, so we cannot expand it", basedOn);
+          console.log("ERROR 6: The basedOn Element has yet to be defined, so we cannot expand it");
+          console.log(dataelement.basedOn);
         } else {
           console.log("ERROR 3: Invalid based on for element " + dataelement.label + " while building field list for " + concreteDataelement.label + ". Based on:");
           console.log(dataelement.basedOn);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -237,10 +237,11 @@ module.exports = function(grunt) {
     // follow the inheritance hierarchy up adding to the fields for the current concreteDataelement
     if (dataelement.basedOn) { // add parent fields
       _.forEach(dataelement.basedOn, function(basedOn) {
-        if (basedOn.label) {
+        if (basedOn.label && basedOn.namespace) {
           //console.log(basedOn.namespace + " / " + basedOn.label);
           createFieldList(concreteDataelement, basedOn.namespace, namespaces[basedOn.namespace].index[basedOn.label]);
         } else if (basedOn.type === "TBD") {
+          console.log("The basedOn Element %s has yet to be defined, so we cannot expand it", basedOn);
         } else {
           console.log("ERROR 3: Invalid based on for element " + dataelement.label + " while building field list for " + concreteDataelement.label + ". Based on:");
           console.log(dataelement.basedOn);

--- a/assets/data/data.json
+++ b/assets/data/data.json
@@ -10,28 +10,22 @@
           "label": "shr.actor",
           "type": "Namespace",
           "description": "The SHR Actor domain contains definitions for people and organizations that are involved with the person of record, in some capacity.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "ActiveFlag",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "If the ActiveFlag is false, it indicates the record is no longer to be used and should generally be hidden for the user in the UI.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -52,6 +46,7 @@
               "type": "DataElement",
               "label": "AdministrativeGender",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1550327",
@@ -63,8 +58,8 @@
               ],
               "description": "A gender classification used for administrative purposes. Administrative gender is not necessarily the same as a biological description or a gender identity. This attribute does not include terms related to clinical gender.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -74,6 +69,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/administrative-gender",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -91,6 +87,7 @@
               "type": "DataElement",
               "label": "Affiliation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0932026",
@@ -102,8 +99,8 @@
               ],
               "description": "Membership, association, or connection to an organization.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -124,6 +121,7 @@
               "type": "DataElement",
               "label": "AgeAtDeath",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1546180",
@@ -135,8 +133,8 @@
               ],
               "description": "The age, age range, or age group when the cessation of life happens.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -157,6 +155,7 @@
               "type": "DataElement",
               "label": "Anonymized",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3858751",
@@ -168,8 +167,8 @@
               ],
               "description": "Flag indicating if personally identifiable information has been withheld.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -190,6 +189,7 @@
               "type": "DataElement",
               "label": "DateOfBirth",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2919018",
@@ -208,8 +208,8 @@
               ],
               "description": "A date of birth or approximate year or period (year or date range), if estimated.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -250,6 +250,7 @@
               "type": "DataElement",
               "label": "DateOfDeath",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1148348",
@@ -261,8 +262,8 @@
               ],
               "description": "The calendar date of subject's death.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -283,6 +284,7 @@
               "type": "DataElement",
               "label": "Deceased",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0011065",
@@ -294,8 +296,8 @@
               ],
               "description": "An indication that the person is no longer living, given by a date, time of death, or a boolean value which, when true, indicates the person is deceased.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -341,6 +343,7 @@
               "type": "DataElement",
               "label": "EmergencyContact",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1552023",
@@ -352,8 +355,8 @@
               ],
               "description": "A personal contact specifically designated to be used for emergencies.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -404,6 +407,7 @@
               "type": "DataElement",
               "label": "FictionalPerson",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0887933",
@@ -415,8 +419,8 @@
               ],
               "description": "Flag indicating if this record represents a fictional (synthetic, not real) person.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -437,56 +441,32 @@
               "type": "DataElement",
               "label": "HealthcareRole",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A type of service provided to the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
-                "type": "ChoiceValue",
-                "value": [
+                "constraints": [
                   {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [
-                      {
-                        "type": "ValueSetConstraint",
-                        "valueset": "http://standardhealthrecord.org/shr/actor/vs/HealthcareRoleVS",
-                        "path": ""
-                      }
-                    ],
-                    "type": "IdentifiableValue",
-                    "label": "shr.core:CodeableConcept",
-                    "identifier": {
-                      "label": "CodeableConcept",
-                      "type": "Identifier",
-                      "namespace": "shr.core"
-                    }
-                  },
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [
-                      {
-                        "type": "ValueSetConstraint",
-                        "valueset": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
-                        "path": ""
-                      }
-                    ],
-                    "type": "IdentifiableValue",
-                    "label": "shr.core:CodeableConcept",
-                    "identifier": {
-                      "label": "CodeableConcept",
-                      "type": "Identifier",
-                      "namespace": "shr.core"
-                    }
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/actor/vs/HealthcareRoleVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
                   }
-                ]
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
               },
               "children": []
             },
@@ -494,11 +474,12 @@
               "type": "DataElement",
               "label": "LanguageQualifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Additional information about a person's use of language.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -508,6 +489,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/actor/vs/LanguageQualifierVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -525,11 +507,12 @@
               "type": "DataElement",
               "label": "LanguageUsed",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Language used for communication by a human, either the subject of record, parent, or other involved person.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -586,6 +569,7 @@
               "type": "DataElement",
               "label": "MedicalSpecialty",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0037778",
@@ -597,8 +581,8 @@
               ],
               "description": "A branch of medicine practiced by the provider.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -608,6 +592,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/c80-practice-codes",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -625,6 +610,7 @@
               "type": "DataElement",
               "label": "NationalProviderIdentifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1549728",
@@ -636,8 +622,8 @@
               ],
               "description": "A unique 10-digit number to allow providers to identify themselves in a standard way throughout their industry.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -645,9 +631,9 @@
                 "max": 1,
                 "constraints": [],
                 "type": "IdentifiableValue",
-                "label": "shr.core:Identifier",
+                "label": "shr.core:OrganizationalIdentifier",
                 "identifier": {
-                  "label": "Identifier",
+                  "label": "OrganizationalIdentifier",
                   "type": "Identifier",
                   "namespace": "shr.core"
                 }
@@ -658,11 +644,12 @@
               "type": "DataElement",
               "label": "NoPrimaryCareProvider",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "The medical professional responsible for first-line care of an individual.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -729,6 +716,7 @@
               "type": "DataElement",
               "label": "Organization",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1561598",
@@ -740,8 +728,8 @@
               ],
               "description": "A social or legal structure formed by human beings.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -771,13 +759,20 @@
                 {
                   "min": 1,
                   "max": 1,
-                  "constraints": [],
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/organization-type",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
                   "type": "IdentifiableValue",
-                  "label": "shr.actor:OrganizationType",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "OrganizationType",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.actor"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -831,11 +826,12 @@
               "type": "DataElement",
               "label": "OrganizationAlias",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A list of alternate names that the organization is known as, or was known as in the past.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -856,11 +852,12 @@
               "type": "DataElement",
               "label": "OrganizationIdentifyingCode",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A code identifying a specific organization. The NPI should be provided, if available. Other business identifiers, such employer tax ID, or MVX code for vaccine manufacturers, should also be provided.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -868,9 +865,9 @@
                 "max": 1,
                 "constraints": [],
                 "type": "IdentifiableValue",
-                "label": "shr.core:Identifier",
+                "label": "shr.core:OrganizationalIdentifier",
                 "identifier": {
-                  "label": "Identifier",
+                  "label": "OrganizationalIdentifier",
                   "type": "Identifier",
                   "namespace": "shr.core"
                 }
@@ -881,11 +878,12 @@
               "type": "DataElement",
               "label": "OrganizationName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The name of the organization.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -904,39 +902,9 @@
             },
             {
               "type": "DataElement",
-              "label": "OrganizationType",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A classification of the organization in terms of its major role in healthcare.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/organization-type",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "Participant",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1550369",
@@ -948,8 +916,8 @@
               ],
               "description": "A statement about an actor who did (or did not) participate in a certain task or activity. Unlike a HealthcareInvolvement which continues over period of time, the participant is associated with doing or not doing a specific task, such admitting a patient, performing a procedure, or taking a measurement.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1051,6 +1019,7 @@
               "type": "DataElement",
               "label": "ParticipationType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1553854",
@@ -1062,14 +1031,21 @@
               ],
               "description": "The detail of how the performer engaged in the task, for example, as the attending physician, surgical assistant, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://hl7.org/fhir/ValueSet/v3-ParticipationType",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
                 "type": "IdentifiableValue",
                 "label": "shr.core:CodeableConcept",
                 "identifier": {
@@ -1084,6 +1060,7 @@
               "type": "DataElement",
               "label": "Person",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0027361",
@@ -1095,22 +1072,22 @@
               ],
               "description": "A person. In practical terms, people relevant to the health or social situation of the subject (including the person of record).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
-              "value": {
-                "min": 0,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:HumanName",
-                "identifier": {
-                  "label": "HumanName",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
               "children": [
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:HumanName",
+                  "identifier": {
+                    "label": "HumanName",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
                 {
                   "min": 0,
                   "max": 1,
@@ -1210,6 +1187,7 @@
               "type": "DataElement",
               "label": "Practitioner",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2220264",
@@ -1221,8 +1199,8 @@
               ],
               "description": "A person who practices a healing art.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -1232,19 +1210,18 @@
                   "namespace": "shr.actor"
                 }
               ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:HumanName",
-                "identifier": {
-                  "label": "HumanName",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
               "children": [
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:HumanName",
+                  "identifier": {
+                    "label": "HumanName",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
                 {
                   "min": 0,
                   "constraints": [],
@@ -1285,6 +1262,7 @@
               "type": "DataElement",
               "label": "PrimaryCareProvider",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2735026",
@@ -1296,8 +1274,8 @@
               ],
               "description": "The medical professional responsible for first-line care of an individual.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -1360,6 +1338,7 @@
               "type": "DataElement",
               "label": "Provider",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1138603",
@@ -1371,8 +1350,8 @@
               ],
               "description": "A person or organization who provides services. This includes healthcare and relevant non-healthcare services, including personal services such as transportation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1425,6 +1404,7 @@
               "type": "DataElement",
               "label": "ProviderRelationship",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1314939",
@@ -1436,8 +1416,8 @@
               ],
               "description": "A person or organization responsible for providing a service to the person of record. Such a relationship can exist without a specific encounter or services being rendered; for example, an emergency contact relationship can exist without ever calling upon that person. The entry can also be used to state that a provider relationship does not exist, e.g., patient does not have a primary care provider.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -1507,11 +1487,12 @@
               "type": "DataElement",
               "label": "RelatedPerson",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A person, other than a practitioner or the patient (the person of record) who is relevant to the health or social situation of the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -1527,6 +1508,7 @@
               "type": "DataElement",
               "label": "SpokenLanguageProficiency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0678997",
@@ -1538,8 +1520,8 @@
               ],
               "description": "Accuracy and fluency in spoken communication in a language.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1549,6 +1531,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -1566,6 +1549,7 @@
               "type": "DataElement",
               "label": "WrittenLanguageProficiency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0586739",
@@ -1577,8 +1561,8 @@
               ],
               "description": "Accuracy and fluency of reading and writing in a language.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1588,6 +1572,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -1607,45 +1592,32 @@
           "label": "shr.adverse",
           "type": "Namespace",
           "description": "The SHR Adverse domain contains definitions for describing adverse events and adverse reactions.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
-              "label": "AdverseReaction",
+              "label": "AdverseEvent",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
-                  "label": "http://ncimeta.nci.nih.gov:C0559966",
+                  "label": "http://ncimeta.nci.nih.gov:C0877248",
                   "type": "Concept",
                   "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0559966",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0559966;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                  "code": "C0877248",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0877248;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "Any noxious and unintended response to a medical product, procedure, or other intervention, for which a causal relationship to an intervention is at least a reasonable possibility i.e., the relationship cannot be ruled out. It is not necessarily associated with a previously-recorded SubstanceRisk. This entry could be used to record the occurrence or non-occurrence of an adverse reaction.",
+              "description": "Any unfavorable and unintended sign, symptom, disease, or other medical occurrence with a temporal association with the use of a medical product, procedure or other therapy, or in conjunction with a research study, regardless of causal relationship. EXAMPLE(S): death, back pain, headache, pulmonary embolism, heart attack.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
-              "basedOn": [
-                {
-                  "label": "Problem",
-                  "type": "Identifier",
-                  "namespace": "shr.problem"
-                }
-              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -1653,6 +1625,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/adverse/vs/MedDRAVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -1667,25 +1640,14 @@
               "children": [
                 {
                   "min": 1,
-                  "constraints": [
-                    {
-                      "type": "IncludesCodeConstraint",
-                      "code": {
-                        "label": "null:adverse_reaction",
-                        "type": "Concept",
-                        "system": null,
-                        "code": "adverse_reaction",
-                        "url": ""
-                      },
-                      "path": ""
-                    }
-                  ],
+                  "max": 1,
+                  "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:ProblemCategory",
+                  "label": "shr.adverse:AdverseEventGrade",
                   "identifier": {
-                    "label": "ProblemCategory",
+                    "label": "AdverseEventGrade",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.adverse"
                   }
                 },
                 {
@@ -1693,24 +1655,148 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.adverse:SeriousAdverseEvent",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "SeriousAdverseEvent",
                     "type": "Identifier",
-                    "namespace": "shr.base"
+                    "namespace": "shr.adverse"
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "TBD",
+                  "text": "PatternOfEvent"
+                },
+                {
+                  "min": 0,
+                  "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.adverse:AdverseEventOutcome",
                   "identifier": {
-                    "label": "Manifestation",
+                    "label": "AdverseEventOutcome",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.adverse"
                   }
                 },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:AssociatedStudy",
+                  "identifier": {
+                    "label": "AssociatedStudy",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "AdverseEventGrade",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C2985911",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C2985911",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C2985911;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A coded value specifying the level of injury suffered by the subject for whom the event is reported, using the CTCAE coding system.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/adverse/vs/AdverseEventGradeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "AdverseEventOutcome",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The eventual result and impact of an adverse event",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://hl7.org/fhir/ValueSet/adverse-event-outcome",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "AdverseReaction",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0559966",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0559966",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0559966;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Any noxious and unintended response to a medical product, procedure, or other intervention, for which a causal relationship to an intervention is at least a reasonable possibility i.e., the relationship cannot be ruled out. The AssessmentFocus is one or more observations, typically the symptoms of the adverse reaction, such as severe nausea or elevated liver enyzmes.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "AdverseEvent",
+                  "type": "Identifier",
+                  "namespace": "shr.adverse"
+                }
+              ],
+              "children": [
                 {
                   "min": 0,
                   "constraints": [],
@@ -1727,20 +1813,6 @@
                   "max": 1,
                   "constraints": [],
                   "type": "TBD",
-                  "text": "PatternOfEvent"
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "AssociatedStudy"
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "TBD",
                   "text": "ActionTakenWithMedication"
                 },
                 {
@@ -1749,13 +1821,6 @@
                   "constraints": [],
                   "type": "TBD",
                   "text": "OtherActionTaken"
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "Outcome"
                 }
               ]
             },
@@ -1763,6 +1828,7 @@
               "type": "DataElement",
               "label": "AdverseReactionAttribution",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "Adverse Event Attribution to Product or Procedure (http://ncimeta.nci.nih.gov:C1510821)",
@@ -1773,61 +1839,101 @@
                   "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1510821;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "The cause of the adverse reaction (either known or theorized).",
+              "description": "A possible cause of the adverse reaction (either known or theorized). There can be more than one possible cause.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.medication:MedicationUse",
+                    "identifier": {
+                      "label": "MedicationUse",
+                      "type": "Identifier",
+                      "namespace": "shr.medication"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.procedure:Procedure",
+                    "identifier": {
+                      "label": "Procedure",
+                      "type": "Identifier",
+                      "namespace": "shr.procedure"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.medication:Medication",
+                    "identifier": {
+                      "label": "Medication",
+                      "type": "Identifier",
+                      "namespace": "shr.medication"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.device:Device",
+                    "identifier": {
+                      "label": "Device",
+                      "type": "Identifier",
+                      "namespace": "shr.device"
+                    }
+                  }
+                ]
               },
               "children": [
                 {
                   "min": 1,
                   "max": 1,
                   "constraints": [],
-                  "type": "ChoiceValue",
-                  "value": [
-                    {
-                      "min": 1,
-                      "max": 1,
-                      "constraints": [],
-                      "type": "IdentifiableValue",
-                      "label": "shr.core:Substance",
-                      "identifier": {
-                        "label": "Substance",
-                        "type": "Identifier",
-                        "namespace": "shr.core"
-                      }
-                    },
-                    {
-                      "constraints": [],
-                      "type": "TBD",
-                      "text": "Procedure"
-                    }
-                  ]
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.adverse:AttributionCertainty",
+                  "label": "shr.core:Certainty",
                   "identifier": {
-                    "label": "AttributionCertainty",
+                    "label": "Certainty",
                     "type": "Identifier",
-                    "namespace": "shr.adverse"
+                    "namespace": "shr.core"
                   }
                 }
               ]
             },
             {
               "type": "DataElement",
-              "label": "AttributionCertainty",
+              "label": "SeriousAdverseEvent",
               "isEntry": false,
-              "concepts": [],
-              "description": "A specific identifiable level (defined qualitatively or quantitatively) of probability of adverse event being caused or associated with the product or procedure administration to a patient.",
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1710056",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1710056",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1710056;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Clinical significance of adverse event defined based on the patient and event outcome or action criteria usually associated with events that pose a threat to a patient's life or functioning. Seriousness of adverse event serves as a primary guide for defining regulatory reporting obligations and changes in medicinal product development and usage.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1836,7 +1942,8 @@
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/reaction-event-certainty",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/ThreeValueLogicVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -1856,28 +1963,22 @@
           "label": "shr.allergy",
           "type": "Namespace",
           "description": "The SHR Allergy domain contains definitions for statements dealing with substance-related risks, including allergies and intolerances.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "AdverseReactionType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Identification of the underlying physiological mechanism for a Reaction Risk.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1887,6 +1988,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/allergy-intolerance-type",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -1904,6 +2006,7 @@
               "type": "DataElement",
               "label": "AllergenIrritant",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://snomed.info/sct:105590001",
@@ -1915,8 +2018,8 @@
               ],
               "description": "A material, mixture, class or category of substance, including drugs, foods, environmental agents, etc. that may be implicated as a cause of intolerances and allergies.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -1926,6 +2029,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/allergy/vs/AllergenIrritantVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -1943,6 +2047,7 @@
               "type": "DataElement",
               "label": "AllergyIntolerance",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "Propensity to adverse reactions (http://snomed.info/sct:420134006)",
@@ -1953,10 +2058,10 @@
                   "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=420134006"
                 }
               ],
-              "description": "A statement pertaining to an individual's allergies and intolerances to substances or classes of substances. Can be used to record that a substance does not pose an elevated risk to the subject (NonOccurrenceModifier = true).",
+              "description": "A statement pertaining to an individual's allergies and intolerances to substances or classes of substances. Can be used to record that a substance does not pose an elevated risk to the subject (AssertionNegationModifier = true).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -1988,9 +2093,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.base:AssertionNegationModifier",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "AssertionNegationModifier",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -2024,22 +2129,22 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
+                  "label": "shr.condition:Criticality",
                   "identifier": {
                     "label": "Criticality",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
                   "min": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.observation:Manifestation",
                   "identifier": {
                     "label": "Manifestation",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -2047,11 +2152,11 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
+                  "label": "shr.condition:Onset",
                   "identifier": {
                     "label": "Onset",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2059,11 +2164,11 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Abatement",
+                  "label": "shr.condition:Abatement",
                   "identifier": {
                     "label": "Abatement",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2095,11 +2200,12 @@
               "type": "DataElement",
               "label": "AllergyVerificationStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether an assessment has been confirmed by testing or observation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -2109,6 +2215,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/allergy/vs/AllergyVerificationStatusVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -2126,6 +2233,7 @@
               "type": "DataElement",
               "label": "DrugAllergy",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0013182",
@@ -2137,8 +2245,8 @@
               ],
               "description": "An immune or biochemical adverse reaction to a medication.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -2149,24 +2257,6 @@
                 }
               ],
               "children": [
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/allergy/vs/DrugIngredientVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.allergy:AllergenIrritant",
-                  "identifier": {
-                    "label": "AllergenIrritant",
-                    "type": "Identifier",
-                    "namespace": "shr.allergy"
-                  }
-                },
                 {
                   "min": 1,
                   "max": 1,
@@ -2219,6 +2309,7 @@
               "type": "DataElement",
               "label": "FoodAllergy",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0016470",
@@ -2230,8 +2321,8 @@
               ],
               "description": "An immune or biochemical adverse reaction to a food substance.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -2242,24 +2333,6 @@
                 }
               ],
               "children": [
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/allergy/vs/FoodSubstanceVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.allergy:AllergenIrritant",
-                  "identifier": {
-                    "label": "AllergenIrritant",
-                    "type": "Identifier",
-                    "namespace": "shr.allergy"
-                  }
-                },
                 {
                   "min": 1,
                   "max": 1,
@@ -2312,11 +2385,12 @@
               "type": "DataElement",
               "label": "MostRecentOccurrence",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The time of the last or latest of a series of events.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -2337,6 +2411,7 @@
               "type": "DataElement",
               "label": "NoKnownAllergy",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0262580",
@@ -2348,8 +2423,8 @@
               ],
               "description": "The subject has no known allergies to drugs, foods, biologics, or environmental factors.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -2428,8 +2503,6 @@
                   }
                 },
                 {
-                  "min": 1,
-                  "max": 1,
                   "constraints": [
                     {
                       "type": "BooleanConstraint",
@@ -2438,9 +2511,9 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.base:AssertionNegationModifier",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "AssertionNegationModifier",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -2494,11 +2567,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
+                  "label": "shr.condition:Criticality",
                   "identifier": {
                     "label": "Criticality",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2506,11 +2579,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.observation:Manifestation",
                   "identifier": {
                     "label": "Manifestation",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -2518,11 +2591,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
+                  "label": "shr.condition:Onset",
                   "identifier": {
                     "label": "Onset",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2555,6 +2628,7 @@
               "type": "DataElement",
               "label": "NoKnownDrugAllergy",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0262581",
@@ -2566,8 +2640,8 @@
               ],
               "description": "The subject has no known allergies to any medications.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -2623,9 +2697,9 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.base:AssertionNegationModifier",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "AssertionNegationModifier",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -2679,11 +2753,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
+                  "label": "shr.condition:Criticality",
                   "identifier": {
                     "label": "Criticality",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2691,11 +2765,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.observation:Manifestation",
                   "identifier": {
                     "label": "Manifestation",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -2703,11 +2777,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
+                  "label": "shr.condition:Onset",
                   "identifier": {
                     "label": "Onset",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2740,6 +2814,7 @@
               "type": "DataElement",
               "label": "NoKnownEnvironmentalAllergy",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1998290",
@@ -2751,8 +2826,8 @@
               ],
               "description": "The subject has no known allergies to any environmental factors.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -2808,9 +2883,9 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.base:AssertionNegationModifier",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "AssertionNegationModifier",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -2864,11 +2939,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
+                  "label": "shr.condition:Criticality",
                   "identifier": {
                     "label": "Criticality",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2876,11 +2951,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.observation:Manifestation",
                   "identifier": {
                     "label": "Manifestation",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -2888,11 +2963,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
+                  "label": "shr.condition:Onset",
                   "identifier": {
                     "label": "Onset",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -2925,6 +3000,7 @@
               "type": "DataElement",
               "label": "NoKnownFoodAllergy",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1997970",
@@ -2936,8 +3012,8 @@
               ],
               "description": "The subject has no known allergies to any foods.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -2993,9 +3069,9 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.base:AssertionNegationModifier",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "AssertionNegationModifier",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -3049,11 +3125,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
+                  "label": "shr.condition:Criticality",
                   "identifier": {
                     "label": "Criticality",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -3061,11 +3137,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.observation:Manifestation",
                   "identifier": {
                     "label": "Manifestation",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -3073,11 +3149,11 @@
                   "max": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
+                  "label": "shr.condition:Onset",
                   "identifier": {
                     "label": "Onset",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
@@ -3110,11 +3186,12 @@
               "type": "DataElement",
               "label": "SubstanceCategory",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Categorization of the risk substance as a food, drug, or environmental agent. For difficult-to-classify substances, one can leave this field empty or choose the most typical category.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3124,6 +3201,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/allergy-intolerance-category",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -3140,31 +3218,351 @@
           ]
         },
         {
+          "label": "shr.assessment",
+          "type": "Namespace",
+          "description": "The SHR Assessment domain contains definitions used to capture judgments, medical opinions, clinical impressions, diagnoses, and inferences drawn from evidence.",
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "type": "DataElement",
+              "label": "Assessment",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0220825",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0220825",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0220825;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A conclusion (tentative or final) resulting from synthesis of evidence (one or more observations). An Assessment is a judgment rendered at a point in time. A diagnosis is a type of Assessment that can lead to creation of a Condition.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Action",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
+              "children": [
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/assessment/vs/AssessmentTypeVS",
+                      "bindingStrength": "EXTENSIBLE",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/clinical-impression-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Status",
+                  "identifier": {
+                    "label": "Status",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.assessment:AssessmentFocus",
+                  "identifier": {
+                    "label": "AssessmentFocus",
+                    "type": "Identifier",
+                    "namespace": "shr.assessment"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.assessment:AssessmentResult",
+                  "identifier": {
+                    "label": "AssessmentResult",
+                    "type": "Identifier",
+                    "namespace": "shr.assessment"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Method",
+                  "identifier": {
+                    "label": "Method",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:ClinicallyRelevantTime",
+                  "identifier": {
+                    "label": "ClinicallyRelevantTime",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.assessment:EvidenceQuality",
+                  "identifier": {
+                    "label": "EvidenceQuality",
+                    "type": "Identifier",
+                    "namespace": "shr.assessment"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Evidence",
+                  "identifier": {
+                    "label": "Evidence",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Summary",
+                  "identifier": {
+                    "label": "Summary",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "AssessmentFocus",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The topic or target of an analysis or assessment. For example, if the question involves the progression of the subject's diabetes, then the FocalCondition would be diabetes. If the investigation involves the toxicity of chemotherapy regimen, the focus would be that regimen (currently the MedicationUse of the chemotherapy drug). If the analysis involves certain observations, they would be listed as the focus.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.procedure:Procedure",
+                    "identifier": {
+                      "label": "Procedure",
+                      "type": "Identifier",
+                      "namespace": "shr.procedure"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.observation:Observation",
+                    "identifier": {
+                      "label": "Observation",
+                      "type": "Identifier",
+                      "namespace": "shr.observation"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.condition:Condition",
+                    "identifier": {
+                      "label": "Condition",
+                      "type": "Identifier",
+                      "namespace": "shr.condition"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.allergy:AllergyIntolerance",
+                    "identifier": {
+                      "label": "AllergyIntolerance",
+                      "type": "Identifier",
+                      "namespace": "shr.allergy"
+                    }
+                  }
+                ]
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "AssessmentResult",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A statement of judgment or opinion, often the outcome, finding, or conclusion of the investigation or analysis.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:AssertionNegationModifier",
+                  "identifier": {
+                    "label": "AssertionNegationModifier",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Certainty",
+                  "identifier": {
+                    "label": "Certainty",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "EvidenceQuality",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "An estimate of the quality and/or quantity of the source information that supports the assessment.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/assessment/vs/EvidenceQualityVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            }
+          ]
+        },
+        {
           "label": "shr.base",
           "type": "Namespace",
           "description": "The SHR Base domain contains definitions for elements that are widely shared in SHR, including the base Entry and associated metadata.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "AccessTime",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Point in time when data was accessed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3185,22 +3583,46 @@
               "type": "DataElement",
               "label": "Action",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "An action that either has or has not taken place.",
+              "description": "A deed or endeavor; an action taken to address a undesired health state, behavior, risk, or goal. An action can have various contexts: definitional, occurred/not occurred, ordered/not ordered, recommended/recommended against.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
                 {
                   "min": 1,
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:ActionCode",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "ActionCode",
+                    "label": "Status",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -3219,7 +3641,6 @@
                 },
                 {
                   "min": 0,
-                  "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
                   "label": "shr.core:Reason",
@@ -3256,13 +3677,148 @@
             },
             {
               "type": "DataElement",
-              "label": "ActionCode",
+              "label": "AssertionNegationModifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "The code for the action, such as an intervention or test, to be carried out.",
+              "description": "When true, this modifier indicates that the associated observation, assessment, or finding is false, the condition is absent. For example, if the assessment is 'allergy to peanuts' and the AssertionNegationModifier is true, it means the subject does not have an allergy to peanuts.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:boolean",
+                "identifier": {
+                  "label": "boolean",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "AssociatedEncounter",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The encounter or episode of care that led to creation of this entry.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "RefValue",
+                "label": "reference to shr.encounter:Encounter",
+                "identifier": {
+                  "label": "Encounter",
+                  "type": "Identifier",
+                  "namespace": "shr.encounter"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Author",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The person or organization who created the entry and is responsible for (and may certify) its content.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.demographics:PersonOfRecord",
+                    "identifier": {
+                      "label": "PersonOfRecord",
+                      "type": "Identifier",
+                      "namespace": "shr.demographics"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.actor:Practitioner",
+                    "identifier": {
+                      "label": "Practitioner",
+                      "type": "Identifier",
+                      "namespace": "shr.actor"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.actor:RelatedPerson",
+                    "identifier": {
+                      "label": "RelatedPerson",
+                      "type": "Identifier",
+                      "namespace": "shr.actor"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.actor:Organization",
+                    "identifier": {
+                      "label": "Organization",
+                      "type": "Identifier",
+                      "namespace": "shr.actor"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.device:Device",
+                    "identifier": {
+                      "label": "Device",
+                      "type": "Identifier",
+                      "namespace": "shr.device"
+                    }
+                  }
+                ]
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Category",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A categorization of the action according its type, often a code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This can be used for searching, sorting and display purposes.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3281,102 +3837,9 @@
             },
             {
               "type": "DataElement",
-              "label": "AssociatedEncounter",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The encounter or episode of care that led to creation of this entry.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.encounter:Encounter",
-                "identifier": {
-                  "label": "Encounter",
-                  "type": "Identifier",
-                  "namespace": "shr.encounter"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Author",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The person or organization who created the entry and is responsible for (and may certify) its content.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "ChoiceValue",
-                "value": [
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.demographics:PersonOfRecord",
-                    "identifier": {
-                      "label": "PersonOfRecord",
-                      "type": "Identifier",
-                      "namespace": "shr.demographics"
-                    }
-                  },
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.actor:Practitioner",
-                    "identifier": {
-                      "label": "Practitioner",
-                      "type": "Identifier",
-                      "namespace": "shr.actor"
-                    }
-                  },
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.actor:RelatedPerson",
-                    "identifier": {
-                      "label": "RelatedPerson",
-                      "type": "Identifier",
-                      "namespace": "shr.actor"
-                    }
-                  },
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.actor:Organization",
-                    "identifier": {
-                      "label": "Organization",
-                      "type": "Identifier",
-                      "namespace": "shr.actor"
-                    }
-                  }
-                ]
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "Entry",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1705654",
@@ -3388,8 +3851,8 @@
               ],
               "description": "An item inserted in an electronic record.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -3457,9 +3920,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:SubjectIsThirdPartyModifier",
+                  "label": "shr.base:SubjectIsThirdPartyFlag",
                   "identifier": {
-                    "label": "SubjectIsThirdPartyModifier",
+                    "label": "SubjectIsThirdPartyFlag",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -3566,6 +4029,7 @@
               "type": "DataElement",
               "label": "EntryId",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0600091",
@@ -3577,8 +4041,8 @@
               ],
               "description": "A unique, persistent, permanent identifier for an entry in a health record.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3599,11 +4063,12 @@
               "type": "DataElement",
               "label": "EntryType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The SHR data element identifier, for example, http://standardhealthrecord.org/allergy/SubstanceRisk. The EntryType array includes the entire 'based on' hierarchy to enable searching for classes of things, for example, searching for all vital signs, or all types of behavioral observations.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3624,11 +4089,12 @@
               "type": "DataElement",
               "label": "ExternalHealthRecord",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A health record used to help populate the current health record.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -3637,9 +4103,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.core:Identifier",
+                  "label": "shr.core:OrganizationalIdentifier",
                   "identifier": {
-                    "label": "Identifier",
+                    "label": "OrganizationalIdentifier",
                     "type": "Identifier",
                     "namespace": "shr.core"
                   }
@@ -3662,11 +4128,12 @@
               "type": "DataElement",
               "label": "FocalSubject",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The person or thing that this entry refers to, usually the Person of Record. However, not all entries refer to the Person of Record. The entry could refer to a fetus, care giver, or relative (living or dead).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3679,8 +4146,8 @@
                     "min": 1,
                     "max": 1,
                     "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.demographics:PersonOfRecord",
+                    "type": "RefValue",
+                    "label": "reference to shr.demographics:PersonOfRecord",
                     "identifier": {
                       "label": "PersonOfRecord",
                       "type": "Identifier",
@@ -3691,8 +4158,8 @@
                     "min": 1,
                     "max": 1,
                     "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.actor:Practitioner",
+                    "type": "RefValue",
+                    "label": "reference to shr.actor:Practitioner",
                     "identifier": {
                       "label": "Practitioner",
                       "type": "Identifier",
@@ -3703,8 +4170,8 @@
                     "min": 1,
                     "max": 1,
                     "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.actor:RelatedPerson",
+                    "type": "RefValue",
+                    "label": "reference to shr.actor:RelatedPerson",
                     "identifier": {
                       "label": "RelatedPerson",
                       "type": "Identifier",
@@ -3719,6 +4186,7 @@
               "type": "DataElement",
               "label": "Informant",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0449416",
@@ -3730,8 +4198,8 @@
               ],
               "description": "The person or entity that provided the information in the entry, as distinct from the actor creating the entry, e.g. the subject (patient), medical professional, family member, device or software program.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3784,6 +4252,7 @@
               "type": "DataElement",
               "label": "Language",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0023008",
@@ -3795,8 +4264,8 @@
               ],
               "description": "A human language, spoken or written.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3806,6 +4275,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/languages",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -3823,11 +4293,12 @@
               "type": "DataElement",
               "label": "LastUpdateDate",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A date that the entry was changed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3848,11 +4319,12 @@
               "type": "DataElement",
               "label": "MissingValueReason",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The reason a required element, complex type, or primitive value is missing. Missing value reason can be substituted for any value. By convention in SHR, any required element or value can be substituted with a missing value reason.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3862,6 +4334,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/base/vs/MissingValueReasonVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -3879,11 +4352,12 @@
               "type": "DataElement",
               "label": "Narrative",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A human-readable narrative, potentially including images, that contains a summary of the resource, and may be used to represent the content of the resource to a human.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3917,11 +4391,12 @@
               "type": "DataElement",
               "label": "NarrativeQualifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Additional information on how the narrative was generated, and the scope of information contained.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3931,6 +4406,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/narrative-status",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -3948,11 +4424,12 @@
               "type": "DataElement",
               "label": "NonOccurrenceModifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "When true, indicates either that the event or action documented in the entry did not occur, or the the thing documented is absent or does not exist.",
+              "description": "When true, indicates either that the event or action documented in the entry did not occur. For example, if immunization is not given, the NonOccurrenceModifier=true will indicate this.\nWhen applied to a recommendation, the modifier indicates the action mentioned in the topic should not take place. For example, a request to NOT elevate the head of a bed using the code for elevating the bed, and setting ProhibitedModifier to true. Other examples include do not ambulate, do not flush NG tube, do not take blood pressure on a certain arm, etc. If the SpecificType contains negation and ProhibitedModifier is true, that will reinforce the prohibition, and should not be interpreted as a double negative that equals a positive.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -3986,6 +4463,7 @@
               "type": "DataElement",
               "label": "OriginalCreationDate",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3669169",
@@ -3997,8 +4475,8 @@
               ],
               "description": "The point in time when the information was recorded in the system of record.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4019,11 +4497,12 @@
               "type": "DataElement",
               "label": "PatientInstructions",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Information for the patient, such as, where to get the test, how to prepare for the test, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4044,11 +4523,12 @@
               "type": "DataElement",
               "label": "PerformerInstructions",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Information for the performer of the test, if needed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4069,11 +4549,12 @@
               "type": "DataElement",
               "label": "PriorityOfRequest",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Urgency level for which results must be reported to the requestor or responsible individual.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4083,6 +4564,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/request-priority",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -4100,6 +4582,7 @@
               "type": "DataElement",
               "label": "Request",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1705178",
@@ -4109,10 +4592,10 @@
                   "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1705178;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "An order for something to take place. Using NonOccurrenceModifier, it may document why a request was NOT made.",
+              "description": "An order for something to take place.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -4124,25 +4607,20 @@
               ],
               "children": [
                 {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.base:RequestNotToPerformActionModifier",
-                  "identifier": {
-                    "label": "RequestNotToPerformActionModifier",
-                    "type": "Identifier",
-                    "namespace": "shr.base"
-                  }
-                },
-                {
                   "min": 1,
                   "max": 1,
-                  "constraints": [],
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/request-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:RequestStatus",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "RequestStatus",
+                    "label": "Status",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -4245,11 +4723,12 @@
               "type": "DataElement",
               "label": "RequestedPerformanceTime",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "When test or tests should be done. If the tests are a series or recur (e.g. daily blood sugar testing in the morning) then a Timing can be used to describe the periodicity.",
+              "description": "When an action should be done. If the action is a series or recurs (e.g. daily blood sugar testing in the morning) then a Timing can be used to describe the periodicity.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4266,6 +4745,18 @@
                     "label": "primitive:dateTime",
                     "identifier": {
                       "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:date",
+                    "identifier": {
+                      "label": "date",
                       "type": "Identifier",
                       "namespace": "primitive"
                     }
@@ -4297,11 +4788,12 @@
               "type": "DataElement",
               "label": "RequestedPerformer",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Who should carry out the tests. For example, the patient or caregiver.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4366,11 +4858,12 @@
               "type": "DataElement",
               "label": "RequestedPerformerType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "What type of actor should carry out the testing.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4389,77 +4882,9 @@
             },
             {
               "type": "DataElement",
-              "label": "RequestNotToPerformActionModifier",
-              "isEntry": false,
-              "concepts": [],
-              "description": "If true, the thing requested should not take place. For example, a request to NOT elevate the head of a bed using the code for elevating the bed, and setting RequestNotToPerformActionModifier to true. Other examples include do not ambulate, do not flush NG tube, do not take blood pressure on a certain arm, etc. If the Request.code and RequestAgainstModifier both contain negation, that will reinforce the prohibition, and should not be interpreted as a double negative that equals a positive.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:boolean",
-                "identifier": {
-                  "label": "boolean",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Reason",
-                  "identifier": {
-                    "label": "Reason",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "RequestStatus",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The extent to which the ordering process has progressed, for this order.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/request-status",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "primitive:code",
-                "identifier": {
-                  "label": "code",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "ShrId",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0600091",
@@ -4471,8 +4896,8 @@
               ],
               "description": "A unique, persistent identifier for the Standard Health Record to which this entry belongs.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4491,13 +4916,119 @@
             },
             {
               "type": "DataElement",
-              "label": "SubjectIsThirdPartyModifier",
+              "label": "Status",
               "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0449438",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0449438",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0449438;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The position of affairs at a particular time",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:code",
+                    "identifier": {
+                      "label": "code",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Coding",
+                    "identifier": {
+                      "label": "Coding",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  }
+                ]
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Study",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A clinical trial or other formal study.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Title",
+                  "identifier": {
+                    "label": "Title",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Identifier",
+                  "identifier": {
+                    "label": "Identifier",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "SubjectIsThirdPartyFlag",
+              "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "If true, the subject of this entry is someone other than the Person of Record, for example, a family member.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4520,23 +5051,17 @@
           "label": "shr.behavior",
           "type": "Namespace",
           "description": "The SHR Behavior domain contains data definitions related to how the person of record acts, feels, or responds to situations.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "AlcoholBingeFrequency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0556346",
@@ -4548,8 +5073,8 @@
               ],
               "description": "How often have you had 6 or more Units if female, or 8 or more if male, on a single occasion in the last year?.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -4559,6 +5084,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -4588,11 +5114,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -4601,6 +5127,7 @@
               "type": "DataElement",
               "label": "AlcoholUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0001948",
@@ -4612,8 +5139,8 @@
               ],
               "description": "The history of the subject's use of alcohol.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -4630,6 +5157,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "urn:tbd:AlcoholUseVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -4657,11 +5185,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -4694,7 +5222,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/behavior/vs/AlcoholUseScreeningToolVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -4723,13 +5252,21 @@
               "type": "DataElement",
               "label": "AssessmentTool",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The name of the formal assessment or screening tool used to assess the behavior.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Method",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -4748,6 +5285,7 @@
               "type": "DataElement",
               "label": "BehavioralObservation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0004927",
@@ -4759,8 +5297,8 @@
               ],
               "description": "A statement about observable responses, actions, or activities of the subject. Can be used to assert or deny behaviors.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -4772,7 +5310,6 @@
               ],
               "children": [
                 {
-                  "min": 1,
                   "constraints": [
                     {
                       "type": "IncludesCodeConstraint",
@@ -4788,11 +5325,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Category",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -4812,6 +5349,27 @@
                     "type": "Identifier",
                     "namespace": "shr.behavior"
                   }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "TypeConstraint",
+                      "isA": {
+                        "_namespace": "shr.behavior",
+                        "_name": "AssessmentTool"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Method",
+                  "identifier": {
+                    "label": "Method",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
                 }
               ]
             },
@@ -4819,6 +5377,7 @@
               "type": "DataElement",
               "label": "DietAndNutrition",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0012155",
@@ -4830,8 +5389,8 @@
               ],
               "description": "The usual food and drink consumed by an individual.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -4848,6 +5407,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "urn:tbd:DietAndNutritionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -4875,11 +5435,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -4894,7 +5454,7 @@
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
@@ -4933,13 +5493,21 @@
               "type": "DataElement",
               "label": "DietNutritionConcern",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "An anxiety or worry about the diet or nutritional intake of the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -4947,6 +5515,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/DietNutritionConcernVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -4964,23 +5533,31 @@
               "type": "DataElement",
               "label": "ExerciseHoursPerWeek",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Hours of moderate or vigorous activity per week.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
                 "constraints": [],
                 "type": "IdentifiableValue",
-                "label": "primitive:unsignedInt",
+                "label": "shr.core:Quantity",
                 "identifier": {
-                  "label": "unsignedInt",
+                  "label": "Quantity",
                   "type": "Identifier",
-                  "namespace": "primitive"
+                  "namespace": "shr.core"
                 }
               },
               "children": []
@@ -4989,13 +5566,21 @@
               "type": "DataElement",
               "label": "HasSufficientFood",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "",
+              "description": "Frequency that the person of record unable to obtain food to stay hunger.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -5003,6 +5588,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5020,6 +5606,7 @@
               "type": "DataElement",
               "label": "HoursSleepPerNight",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:65968-0",
@@ -5031,20 +5618,39 @@
               ],
               "description": "Typical hours spent sleeping per night.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:1",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "1",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
                 "type": "IdentifiableValue",
-                "label": "primitive:positiveInt",
+                "label": "shr.core:Quantity",
                 "identifier": {
-                  "label": "positiveInt",
+                  "label": "Quantity",
                   "type": "Identifier",
-                  "namespace": "primitive"
+                  "namespace": "shr.core"
                 }
               },
               "children": []
@@ -5053,6 +5659,7 @@
               "type": "DataElement",
               "label": "IntravenousDrugUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0242566",
@@ -5064,8 +5671,8 @@
               ],
               "description": "Records whether the subject injects recreational drugs.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -5082,6 +5689,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/ThreeValueLogicVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5109,11 +5717,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -5172,6 +5780,7 @@
               "type": "DataElement",
               "label": "NicotineUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2363943",
@@ -5183,8 +5792,8 @@
               ],
               "description": "Records the history of a subject's use of nicotine.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -5201,6 +5810,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-ccdasmokingstatus",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5250,11 +5860,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -5262,7 +5872,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "urn:tbd:NicotineRouteVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -5278,7 +5889,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "urn:tbd:NicotineExposureMethodVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -5295,6 +5907,7 @@
               "type": "DataElement",
               "label": "ONCSmokingStatus",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:11367-0",
@@ -5306,13 +5919,13 @@
               ],
               "description": "Records the subject's use of tobacco.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -5324,6 +5937,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-ccdasmokingstatus",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5351,11 +5965,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -5364,6 +5978,7 @@
               "type": "DataElement",
               "label": "PhysicalActivityLevel",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0026606",
@@ -5375,8 +5990,8 @@
               ],
               "description": "The amount of exercise or other physical activity compared to others of the same age.  See BMC Medical Research Methodology 2012 12:20 1471-2288.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -5393,6 +6008,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeValueScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5420,11 +6036,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -5463,13 +6079,21 @@
               "type": "DataElement",
               "label": "PhysicalActivityLimitation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Anything that limits physical activity, including health factors, logistical, monetary, or social restrictions.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -5477,6 +6101,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/PhysicalActivityLimitationVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5494,11 +6119,12 @@
               "type": "DataElement",
               "label": "ReadinessToChange",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How motivated the subject is to change the behavior, if the behavior is ongoing, and change would be beneficial.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -5508,6 +6134,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeLikelihoodVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5523,51 +6150,18 @@
             },
             {
               "type": "DataElement",
-              "label": "ReligiousCongregation",
+              "label": "Religion",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "A group of place of religious practice.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:string",
-                "identifier": {
-                  "label": "string",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ReligiousPractice",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0035039",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0035039",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0035039;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The religion practiced by the focal subject.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -5578,7 +6172,8 @@
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/v3/ReligiousAffiliation",
+                    "valueset": "http://hl7.org/fhir/ValueSet/v3-ReligiousAffiliation",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5606,11 +6201,86 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ReligiousCongregation",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A group of place of religious practice.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:string",
+                "identifier": {
+                  "label": "string",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ReligiousPractice",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0035039",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0035039",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0035039;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The religion practiced by the focal subject.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Panel",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.behavior:Religion",
+                  "identifier": {
+                    "label": "Religion",
+                    "type": "Identifier",
+                    "namespace": "shr.behavior"
                   }
                 },
                 {
@@ -5661,13 +6331,21 @@
               "type": "DataElement",
               "label": "ReligiousPracticeStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The extent to which the religious practice is actively followed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -5675,6 +6353,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/ReligiousPracticeStatusVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5692,13 +6371,21 @@
               "type": "DataElement",
               "label": "ReligiousRestriction",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Any restriction on that derives from religion and may impact medical treatment, other than dietary (handled elsewhere).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -5706,6 +6393,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/ReligiousRestrictionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5723,6 +6411,7 @@
               "type": "DataElement",
               "label": "SleepQuality",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0424563",
@@ -5734,8 +6423,8 @@
               ],
               "description": "Self-reported sleep quality.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -5752,6 +6441,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5779,11 +6469,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -5851,13 +6541,21 @@
               "type": "DataElement",
               "label": "SleepQualityReason",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Reason for poor sleep quality.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -5865,6 +6563,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/SleepQualityReasonVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5882,13 +6581,21 @@
               "type": "DataElement",
               "label": "SpecialDietFollowed",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A type of nutritional plan followed by the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -5896,6 +6603,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/SpecialDietFollowedVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5913,11 +6621,12 @@
               "type": "DataElement",
               "label": "SubstanceAbuseTreatment",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "The treatment program used to address a substance abuse problem.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -5934,6 +6643,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/behavior/vs/SubstanceAbuseTreatmentTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -5951,6 +6661,7 @@
               "type": "DataElement",
               "label": "SubstanceUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C024251",
@@ -5962,8 +6673,8 @@
               ],
               "description": "Assertion concerning the past or current use of a substance (alcohol, recreational drugs, illegal drugs, or abuse of prescription medication) that could negatively impact the subject's health.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -5991,7 +6702,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/behavior/vs/SubstanceOfAbuseVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -6018,11 +6730,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Category",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 }
               ]
@@ -6031,13 +6743,21 @@
               "type": "DataElement",
               "label": "TroubleFallingAsleep",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often the subject has trouble falling asleep.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -6045,6 +6765,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6062,13 +6783,21 @@
               "type": "DataElement",
               "label": "TroubleStayingAsleep",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often the subject has trouble staying asleep.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -6076,6 +6805,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6093,16 +6823,19 @@
               "type": "DataElement",
               "label": "ViolentBehaviorRisk",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Risk or danger posed by the focal subject to others and/or his or herself due to violent behavior.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "type": "Identifier"
+                  "label": "Panel",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
                 }
               ],
               "children": [
@@ -6136,13 +6869,21 @@
               "type": "DataElement",
               "label": "ViolentRiskToOthers",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Risk or danger posed by the focal subject to others.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -6150,6 +6891,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeValueScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6161,32 +6903,27 @@
                   "namespace": "shr.core"
                 }
               },
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Explanation",
-                  "identifier": {
-                    "label": "Explanation",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
+              "children": []
             },
             {
               "type": "DataElement",
               "label": "ViolentRiskToSelf",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Risk or danger posed by the focal subject to his or herself.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -6194,6 +6931,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeValueScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6205,32 +6943,27 @@
                   "namespace": "shr.core"
                 }
               },
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Explanation",
-                  "identifier": {
-                    "label": "Explanation",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
+              "children": []
             },
             {
               "type": "DataElement",
               "label": "WakeFeelingRested",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often the subject feels rested when they wake up.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -6238,6 +6971,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6254,31 +6988,1453 @@
           ]
         },
         {
+          "label": "shr.careplan",
+          "type": "Namespace",
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "type": "DataElement",
+              "label": "AssociatedGoal",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The goal  associated with this objective.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "RefValue",
+                "label": "reference to shr.careplan:Goal",
+                "identifier": {
+                  "label": "Goal",
+                  "type": "Identifier",
+                  "namespace": "shr.careplan"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "CarePlan",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0178916",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0178916",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0178916;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Describes how one or more practitioners intend to deliver care for a particular patient, group or community for a period of time, possibly limited to care for a specific condition or set of conditions.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Action",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Title",
+                  "identifier": {
+                    "label": "Title",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Description",
+                  "identifier": {
+                    "label": "Description",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/care-plan-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Status",
+                  "identifier": {
+                    "label": "Status",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/care-plan-category",
+                      "bindingStrength": "EXTENSIBLE",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Reason",
+                  "identifier": {
+                    "label": "Reason",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.careplan:Goal",
+                  "identifier": {
+                    "label": "Goal",
+                    "type": "Identifier",
+                    "namespace": "shr.careplan"
+                  }
+                },
+                {
+                  "min": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Action",
+                  "identifier": {
+                    "label": "Action",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Goal",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0018017",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0018017",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0018017;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A broad statement about what should be accomplished and the progress towards that goal. It represents the intended long-term outcome toward which an individual or a group aspires, and toward which, effort is directed, in the form of activities.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Action",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Title",
+                  "identifier": {
+                    "label": "Title",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/goal-category",
+                      "bindingStrength": "EXTENSIBLE",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/goal-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Status",
+                  "identifier": {
+                    "label": "Status",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:RequestedPerformanceTime",
+                  "identifier": {
+                    "label": "RequestedPerformanceTime",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Reason",
+                  "identifier": {
+                    "label": "Reason",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.careplan:ResultAchieved",
+                  "identifier": {
+                    "label": "ResultAchieved",
+                    "type": "Identifier",
+                    "namespace": "shr.careplan"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Annotation",
+                  "identifier": {
+                    "label": "Annotation",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.careplan:Objective",
+                  "identifier": {
+                    "label": "Objective",
+                    "type": "Identifier",
+                    "namespace": "shr.careplan"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Objective",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Describes the  of an expected or desired achievement that is well-defined, specific, measurable, and derived from one or more goals. There are similarities with Observation, since an objective can sometimes be interpreted as a yet-to-be-made, future observation with a certain target result. ",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Action",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/goal-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Status",
+                  "identifier": {
+                    "label": "Status",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/observation/vs/ObservationCategoryVS",
+                      "bindingStrength": "EXTENSIBLE",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.careplan:AssociatedGoal",
+                  "identifier": {
+                    "label": "AssociatedGoal",
+                    "type": "Identifier",
+                    "namespace": "shr.careplan"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:RequestedPerformanceTime",
+                  "identifier": {
+                    "label": "RequestedPerformanceTime",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.careplan:ResultTargeted",
+                  "identifier": {
+                    "label": "ResultTargeted",
+                    "type": "Identifier",
+                    "namespace": "shr.careplan"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.careplan:ResultAchieved",
+                  "identifier": {
+                    "label": "ResultAchieved",
+                    "type": "Identifier",
+                    "namespace": "shr.careplan"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Annotation",
+                  "identifier": {
+                    "label": "Annotation",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Evidence",
+                  "identifier": {
+                    "label": "Evidence",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ResultAchieved",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The actual value or status achieved.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Quantity",
+                    "identifier": {
+                      "label": "Quantity",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:string",
+                    "identifier": {
+                      "label": "string",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:boolean",
+                    "identifier": {
+                      "label": "boolean",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Range",
+                    "identifier": {
+                      "label": "Range",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Ratio",
+                    "identifier": {
+                      "label": "Ratio",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:time",
+                    "identifier": {
+                      "label": "time",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:dateTime",
+                    "identifier": {
+                      "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:TimePeriod",
+                    "identifier": {
+                      "label": "TimePeriod",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  }
+                ]
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ResultTargeted",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The desired value or status to be achieved.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Quantity",
+                    "identifier": {
+                      "label": "Quantity",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:string",
+                    "identifier": {
+                      "label": "string",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:boolean",
+                    "identifier": {
+                      "label": "boolean",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Range",
+                    "identifier": {
+                      "label": "Range",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Ratio",
+                    "identifier": {
+                      "label": "Ratio",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:time",
+                    "identifier": {
+                      "label": "time",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:dateTime",
+                    "identifier": {
+                      "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:TimePeriod",
+                    "identifier": {
+                      "label": "TimePeriod",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  }
+                ]
+              },
+              "children": []
+            }
+          ]
+        },
+        {
+          "label": "shr.condition",
+          "type": "Namespace",
+          "description": "The SHR Condition domain contains basic definitions used to capture information about problems, concerns, complaints, and disorders.",
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "type": "DataElement",
+              "label": "Abatement",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1880019",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1880019",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1880019;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The end, remission or resolution.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:GeneralizedTemporalContext",
+                "identifier": {
+                  "label": "GeneralizedTemporalContext",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "AcademicProblem",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0000873",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0000873",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0000873;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A problem with learning or behavior in a learning environment.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Condition",
+                  "type": "Identifier",
+                  "namespace": "shr.condition"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "urn:tbd:AcademicProblemVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:BodySite",
+                  "identifier": {
+                    "label": "BodySite",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Asplenia",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0600031",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0600031",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0600031;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Congenital absence of spleen.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Condition",
+                  "type": "Identifier",
+                  "namespace": "shr.condition"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://snomed.info/sct:93030006",
+                      "type": "Concept",
+                      "system": "http://snomed.info/sct",
+                      "code": "93030006",
+                      "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=93030006"
+                    },
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ClinicalStatus",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A flag indicating whether the condition is active or inactive, recurring, in remission, or resolved (as of the last update of the Condition).",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://hl7.org/fhir/ValueSet/condition-clinical",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "primitive:code",
+                "identifier": {
+                  "label": "code",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Condition",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0348080",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0348080",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0348080;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A representation of a disorder, abnormality, problem, injury, complaint, risk, functionality, concern, illness, disease, ailment, sickness, affliction, upset, difficulty, disorder, symptom, worry, or trouble. Condition can be used to track a problem or a risk over a period of time. By virtue of its continuity over time, Condition is different from an Observation or Assessment; Observations represents evidence, and an Assessment is a judgment based on evidence and rendered at a point in time. Diagnosis is a type of Assessment that can lead to creation of a Condition (as can an assessment of risk). The two relate because observations can lead to conclusion that a Condition exists. A statement that a certain condition does not exist should be an assessment. Not all conditions are problems, but all problems are (in some sense) conditions.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/condition/vs/ConditionCategoryVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:ClinicalStatus",
+                  "identifier": {
+                    "label": "ClinicalStatus",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:IncludeOnProblemList",
+                  "identifier": {
+                    "label": "IncludeOnProblemList",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Onset",
+                  "identifier": {
+                    "label": "Onset",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:WhenClinicallyRecognized",
+                  "identifier": {
+                    "label": "WhenClinicallyRecognized",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Preexisting",
+                  "identifier": {
+                    "label": "Preexisting",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Abatement",
+                  "identifier": {
+                    "label": "Abatement",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:BodySite",
+                  "identifier": {
+                    "label": "BodySite",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Severity",
+                  "identifier": {
+                    "label": "Severity",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Criticality",
+                  "identifier": {
+                    "label": "Criticality",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Stage",
+                  "identifier": {
+                    "label": "Stage",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Observation",
+                  "identifier": {
+                    "label": "Observation",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Criticality",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "Criticality (http://ncimeta.nci.nih.gov:C3858539)",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C3858539",
+                  "display": "Criticality",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3858539;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The potential clinical harm associated with a condition. When the worst case result is assessed to have a life-threatening or organ system threatening potential, it is considered to be of high criticality.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "primitive:code",
+                "identifier": {
+                  "label": "code",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "IncludeOnProblemList",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Whether or not to include this condition on the subject's current problem list.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:boolean",
+                "identifier": {
+                  "label": "boolean",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Injury",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C3263722",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C3263722",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3263722;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Damage inflicted on the body by an external force.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Condition",
+                  "type": "Identifier",
+                  "namespace": "shr.condition"
+                }
+              ],
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Setting",
+                  "identifier": {
+                    "label": "Setting",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Location",
+                  "identifier": {
+                    "label": "Location",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "MentalHealthCondition",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1446377",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1446377",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1446377;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A condition relating to a person’s psychological and emotional well-being.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Condition",
+                  "type": "Identifier",
+                  "namespace": "shr.condition"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/condition/vs/DSMVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Onset",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0277793",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0277793",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0277793;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The beginning or first appearance of a mental or physical disorder.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:GeneralizedTemporalContext",
+                "identifier": {
+                  "label": "GeneralizedTemporalContext",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Preexisting",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "If the problem or condition existed before the current episode of care.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:boolean",
+                "identifier": {
+                  "label": "boolean",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Severity",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0392364",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0392364",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0392364;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Degree of harshness or extent of a symptom, disorder, or condition.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://hl7.org/fhir/ValueSet/condition-severity",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Stage",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0699749",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0699749",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0699749;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The relative advancement in the course of a disease.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Evidence",
+                  "identifier": {
+                    "label": "Evidence",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "WhenClinicallyRecognized",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The time at which a condition or condition was first identified in a healthcare context.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:GeneralizedTemporalContext",
+                "identifier": {
+                  "label": "GeneralizedTemporalContext",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            }
+          ]
+        },
+        {
           "label": "shr.core",
           "type": "Namespace",
           "description": "The SHR Core domain contains definitions for a variety of general-purpose elements that are used widely in SHR. These include definitions for coding, expressions of time, quantities, addresses, names, and more.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "Address",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "An address expressed using postal conventions (as opposed to GPS or other location definition formats). This data type may be used to convey addresses for use in delivering mail as well as for visiting locations and which might not be valid for mail delivery. There are a variety of postal address formats defined around the world. (Source: HL7 FHIR).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -6360,11 +8516,12 @@
               "type": "DataElement",
               "label": "AddressLine",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Part of an address that contains the house number, apartment number, street name, street direction, P.O. Box number, delivery hints, and similar address information. (Source: HL7 FHIR).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6385,6 +8542,7 @@
               "type": "DataElement",
               "label": "Age",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0001779",
@@ -6396,8 +8554,8 @@
               ],
               "description": "How long something has existed (quantitative).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -6413,6 +8571,7 @@
               "type": "DataElement",
               "label": "AgeGroup",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0027362",
@@ -6424,8 +8583,8 @@
               ],
               "description": "Subgroups of populations based on age.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6435,6 +8594,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/actor/vs/AgeGroupVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6452,11 +8612,12 @@
               "type": "DataElement",
               "label": "AgeRange",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A quantitative range of ages. One of the two ages must be specified.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -6497,6 +8658,7 @@
               "type": "DataElement",
               "label": "Altitude",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0002349",
@@ -6508,8 +8670,8 @@
               ],
               "description": "Height above sea level or above the earth's surface. Measured with with WGS84 datum.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6530,11 +8692,12 @@
               "type": "DataElement",
               "label": "Annotation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A text note which also contains information about who made the statement and when.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6580,6 +8743,7 @@
               "type": "DataElement",
               "label": "Area",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0205146",
@@ -6591,8 +8755,8 @@
               ],
               "description": "The extent of a 2-dimensional surface enclosed within a boundary.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6625,6 +8789,7 @@
               "type": "DataElement",
               "label": "BodyPosition",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1262869",
@@ -6636,8 +8801,8 @@
               ],
               "description": "The position or physical attitude of the body.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6647,6 +8812,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/BodyPositionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6664,19 +8830,20 @@
               "type": "DataElement",
               "label": "BodySite",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
-                  "label": "http://ncimeta.nci.nih.gov:C1268086",
+                  "label": "http://ncimeta.nci.nih.gov:C1545955",
                   "type": "Concept",
                   "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1268086",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1268086;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                  "code": "C1545955",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1545955;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "Location on or in the body.",
+              "description": "A location in the body, including tissues, regions, cavities, and spaces, for example, right elbow, or left ventricle of the heart.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6686,6 +8853,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/BodySiteVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6739,9 +8907,45 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
+                  "label": "shr.core:ClockDirection",
+                  "identifier": {
+                    "label": "ClockDirection",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Distance",
+                  "identifier": {
+                    "label": "Distance",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
                   "label": "shr.core:Description",
                   "identifier": {
                     "label": "Description",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:BodySiteMarker",
+                  "identifier": {
+                    "label": "BodySiteMarker",
                     "type": "Identifier",
                     "namespace": "shr.core"
                   }
@@ -6750,8 +8954,68 @@
             },
             {
               "type": "DataElement",
+              "label": "BodySiteMarker",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A marker surgically placed at the site, often during a biopsy procedure, to pinpoint the location. The marker is typically a metal clip or radioactive seed.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:string",
+                "identifier": {
+                  "label": "string",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Certainty",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The degree of confidence in a conclusion or assertion.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeValueScaleVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
               "label": "Circumference",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0332520",
@@ -6763,8 +9027,8 @@
               ],
               "description": "The length of such a boundary line of a figure, area, or object.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": []
@@ -6773,6 +9037,7 @@
               "type": "DataElement",
               "label": "City",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1555315",
@@ -6784,8 +9049,8 @@
               ],
               "description": "The name of a city, town, village or other community or delivery center. (Source: HL7 FHIR).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6806,6 +9071,7 @@
               "type": "DataElement",
               "label": "ClockDirection",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:72294-2",
@@ -6817,8 +9083,8 @@
               ],
               "description": "A direction indicated by an angle relative to 12 o'clock.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -6828,6 +9094,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/ClockDirectionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -6845,11 +9112,12 @@
               "type": "DataElement",
               "label": "CodeableConcept",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A set of codes drawn from different coding systems, representing the same concept.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -6880,8 +9148,61 @@
             },
             {
               "type": "DataElement",
+              "label": "CodeSystem",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A formal terminology system.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:uri",
+                "identifier": {
+                  "label": "uri",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "CodeSystemVersion",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The version of the vocabulary being used, if applicable.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:string",
+                "identifier": {
+                  "label": "string",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
               "label": "Coding",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0805701",
@@ -6893,12 +9214,12 @@
               ],
               "description": "Coding of a concept, drawn from a controlled vocabulary. Includes the vocabulary and version, if applicable. May include a display text, and a descriptor expressing the intended interpretation of the code.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
-                "min": 1,
+                "min": 0,
                 "max": 1,
                 "constraints": [],
                 "type": "IdentifiableValue",
@@ -6915,9 +9236,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.core:Vocabulary",
+                  "label": "shr.core:CodeSystem",
                   "identifier": {
-                    "label": "Vocabulary",
+                    "label": "CodeSystem",
                     "type": "Identifier",
                     "namespace": "shr.core"
                   }
@@ -6927,9 +9248,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.core:VocabularyVersion",
+                  "label": "shr.core:CodeSystemVersion",
                   "identifier": {
-                    "label": "VocabularyVersion",
+                    "label": "CodeSystemVersion",
                     "type": "Identifier",
                     "namespace": "shr.core"
                   }
@@ -6945,55 +9266,14 @@
                     "type": "Identifier",
                     "namespace": "shr.core"
                   }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:CodingQualifier",
-                  "identifier": {
-                    "label": "CodingQualifier",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
                 }
               ]
             },
             {
               "type": "DataElement",
-              "label": "CodingQualifier",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A description of the purpose or origin of the code that assists in the interpretation of the code.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/core/vs/CodingQualifierVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "primitive:code",
-                "identifier": {
-                  "label": "code",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "Comment",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0947611",
@@ -7005,8 +9285,8 @@
               ],
               "description": "A critical or explanatory note written to discuss, support, explain changes to, or dispute information.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7027,6 +9307,7 @@
               "type": "DataElement",
               "label": "Count",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0750480",
@@ -7038,8 +9319,8 @@
               ],
               "description": "The number of non-null items in a referenced set of items or values.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7060,6 +9341,7 @@
               "type": "DataElement",
               "label": "Country",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0454664",
@@ -7071,8 +9353,8 @@
               ],
               "description": "Country - a nation as commonly understood or generally accepted, expressed in ISO 3166 Alpha-2 (2-letter) codes.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7093,6 +9375,7 @@
               "type": "DataElement",
               "label": "County",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0079170",
@@ -7104,8 +9387,8 @@
               ],
               "description": "The name of the administrative area at a level below that of a state but above that of a city or town. Outside the US, a district or the equivalent. (Source: HL7 FHIR).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7126,6 +9409,7 @@
               "type": "DataElement",
               "label": "Denominator",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2825218",
@@ -7137,8 +9421,8 @@
               ],
               "description": "The divisor of a fraction.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7159,6 +9443,7 @@
               "type": "DataElement",
               "label": "Depth",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0205125",
@@ -7170,8 +9455,8 @@
               ],
               "description": "The extent downward or inward; the perpendicular measurement from the surface downward to determine deepness.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7204,6 +9489,7 @@
               "type": "DataElement",
               "label": "Description",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0678257",
@@ -7215,8 +9501,8 @@
               ],
               "description": "An account, representation, statement, or explanation of something.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7237,6 +9523,7 @@
               "type": "DataElement",
               "label": "Details",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1522508",
@@ -7248,8 +9535,8 @@
               ],
               "description": "Particulars considered individually and in relation to a whole.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7270,6 +9557,7 @@
               "type": "DataElement",
               "label": "Directionality",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/:C99074",
@@ -7281,8 +9569,8 @@
               ],
               "description": "Anatomical location or specimen further detailing directionality.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7292,6 +9580,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/DirectionalityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -7309,6 +9598,7 @@
               "type": "DataElement",
               "label": "DisplayText",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1548311",
@@ -7320,8 +9610,8 @@
               ],
               "description": "A string meant for reading by a person, usually accompanying a code.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7340,8 +9630,55 @@
             },
             {
               "type": "DataElement",
+              "label": "Distance",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0012751",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0012751",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0012751;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The space separating two objects or points.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:TBD",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "TBD",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
               "label": "DollarAmount",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0562019",
@@ -7353,8 +9690,8 @@
               ],
               "description": "An amount of money expressed in US dollars.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -7395,6 +9732,7 @@
               "type": "DataElement",
               "label": "Duration",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0449238",
@@ -7406,8 +9744,8 @@
               ],
               "description": "The length of time that something continues.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -7425,7 +9763,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/core/vs/TimeUnitOfMeasureVS",
-                      "path": "shr.core.Coding"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -7442,6 +9781,7 @@
               "type": "DataElement",
               "label": "EffectiveDate",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1301880",
@@ -7453,8 +9793,8 @@
               ],
               "description": "The date when something is to take effect.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7475,6 +9815,7 @@
               "type": "DataElement",
               "label": "EffectiveTimePeriod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2985763",
@@ -7486,8 +9827,8 @@
               ],
               "description": "The date and time span for which something is active, valid, or in force.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -7503,6 +9844,7 @@
               "type": "DataElement",
               "label": "Explanation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0681841",
@@ -7514,8 +9856,8 @@
               ],
               "description": "A set of statements describing a group of facts that clarifies the cause, context and/or consequence of those facts.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7536,6 +9878,7 @@
               "type": "DataElement",
               "label": "FamilyName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:45394-4",
@@ -7547,8 +9890,8 @@
               ],
               "description": "The portion of a person's name that reflects the genealogy of the person. In western cultures, this is the 'last' name. In eastern cultures, the family name appears before the person's given name(s). In some cultures (e.g. Eritrea) the family name of a son is the first name of his father. (Source: HL7 V3).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7569,6 +9912,7 @@
               "type": "DataElement",
               "label": "Frequency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0376249",
@@ -7580,8 +9924,8 @@
               ],
               "description": "How many occurrences of an event per unit of time.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -7615,11 +9959,12 @@
               "type": "DataElement",
               "label": "GeneralizedAge",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Qualitative or quantitative, exact or inexact description of age.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7672,11 +10017,12 @@
               "type": "DataElement",
               "label": "GeneralizedDateTime",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A point in time, specified qualitatively or quantitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7729,11 +10075,12 @@
               "type": "DataElement",
               "label": "GeneralizedDuration",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The duration of an event, qualitatively or quantitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7774,11 +10121,12 @@
               "type": "DataElement",
               "label": "GeneralizedFrequency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The frequency of an event, qualitatively or quantitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7831,11 +10179,12 @@
               "type": "DataElement",
               "label": "GeneralizedLikelihood",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Quantitative or qualitative measure of likelihood.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7876,11 +10225,12 @@
               "type": "DataElement",
               "label": "GeneralizedTemporalContext",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A generalized indicator of a dateTime or an age when an event happened.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -7933,6 +10283,7 @@
               "type": "DataElement",
               "label": "GeopoliticalLocation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0017446",
@@ -7944,8 +10295,8 @@
               ],
               "description": "The countries of the world and major geopolitical subregions, such as US states.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -7986,11 +10337,12 @@
               "type": "DataElement",
               "label": "Geoposition",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The location on the surface of the Earth, described by a latitude and longitude (and optional altitude).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -8036,6 +10388,7 @@
               "type": "DataElement",
               "label": "GestationalAge",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0017504",
@@ -8047,8 +10400,8 @@
               ],
               "description": "The age of the embryo or fetus. This may be assessed by medical history, physical examination, early immunologic pregnancy tests, radiography, ultrasonography, and amniotic fluid analysis.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8069,11 +10422,12 @@
               "type": "DataElement",
               "label": "GestationalTemporalContext",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A named gestational time period, or a gestational age.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8114,11 +10468,12 @@
               "type": "DataElement",
               "label": "GestationalTimePeriod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A time relative to a pregnancy or childbirth event.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8128,6 +10483,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "urn:tbd:GestationalTimePeriodVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -8145,6 +10501,7 @@
               "type": "DataElement",
               "label": "GivenName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:45392-8",
@@ -8163,8 +10520,8 @@
               ],
               "description": "A set of names given to a person at birth, but not including the family name. In western cultures, this property would contain the 'first' and 'middle' names. Note that in some cultures, the given name is placed after the family name. Note also that this property contains multiple elements, so it can handle those situations where a person has more than one 'middle' name. (Source: HL7 V3).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8185,6 +10542,7 @@
               "type": "DataElement",
               "label": "HumanName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1547383",
@@ -8196,8 +10554,8 @@
               ],
               "description": "A name used by a human being, written as it would be typically expressed. May include a breakdown of the various elements of the name (family name, given name, etc.).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8289,6 +10647,7 @@
               "type": "DataElement",
               "label": "HumanNamePrefix",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3476361",
@@ -8300,8 +10659,8 @@
               ],
               "description": "Contains a set of honorific terms that typically appear before a person's name, for example Mr., Mrs., Dr., etc. Prefixes have a strong association to the immediately following name part. (Source: HL7 V3).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8322,6 +10681,7 @@
               "type": "DataElement",
               "label": "HumanNameSuffix",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:45395-1",
@@ -8340,8 +10700,8 @@
               ],
               "description": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8362,11 +10722,12 @@
               "type": "DataElement",
               "label": "HumanNameUse",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A qualifier specifying how a human name is used by a person, such as a legal name, alias, or nickname.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8376,6 +10737,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/name-use",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -8393,11 +10755,12 @@
               "type": "DataElement",
               "label": "Identifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "A numeric or alphanumeric string that is associated with a single object or entity within a given system. Typically, identifiers are used to connect content in resources to external content available in other frameworks or protocols. Identifiers are associated with objects, and may be changed or retired due to human or system process and errors.",
+              "description": "A unique string that identifies a specific person or thing.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8412,37 +10775,13 @@
                   "namespace": "primitive"
                 }
               },
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:TimePeriod",
-                  "identifier": {
-                    "label": "TimePeriod",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.actor:Organization",
-                  "identifier": {
-                    "label": "Organization",
-                    "type": "Identifier",
-                    "namespace": "shr.actor"
-                  }
-                }
-              ]
+              "children": []
             },
             {
               "type": "DataElement",
               "label": "Laterality",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "Anatomical laterality (http://ncimeta.nci.nih.gov:C0925205)",
@@ -8455,8 +10794,8 @@
               ],
               "description": "Anatomical location or specimen further detailing the side(s) of interest.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8466,6 +10805,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/LateralityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -8483,6 +10823,7 @@
               "type": "DataElement",
               "label": "Latitude",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1627936",
@@ -8494,8 +10835,8 @@
               ],
               "description": "The angular distance north or south between an imaginary line around a heavenly body parallel to its equator and the equator itself. Measured with with WGS84 datum.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8516,6 +10857,7 @@
               "type": "DataElement",
               "label": "Length",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1444754",
@@ -8525,10 +10867,10 @@
                   "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1444754;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "The measurement or linear extent of something from end to end; the greater of two or the greatest of three dimensions of a body.",
+              "description": "The measurement or linear extent of something from end to end; the greatest dimensions of a body.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8561,6 +10903,7 @@
               "type": "DataElement",
               "label": "Likelihood",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0033204",
@@ -8572,8 +10915,8 @@
               ],
               "description": "A measure of the expectation of the occurrence of a particular event, as a percentage.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8594,6 +10937,7 @@
               "type": "DataElement",
               "label": "Location",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0450429",
@@ -8605,8 +10949,8 @@
               ],
               "description": "A position, site, or point in space where something can be found.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8659,6 +11003,7 @@
               "type": "DataElement",
               "label": "Longitude",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1657623",
@@ -8670,8 +11015,8 @@
               ],
               "description": "An imaginary great circle on the surface of a heavenly body passing through the poles at right angles to the equator. Measured with with WGS84 datum.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8692,11 +11037,12 @@
               "type": "DataElement",
               "label": "LowerBound",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A measured or measurable amount with units that is known to be bounded from below by the quantity represented.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -8725,11 +11071,12 @@
               "type": "DataElement",
               "label": "LowerBoundType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Indicates the actual value is gt (>) or gte (>=) the given value.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8739,6 +11086,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/LowerBoundTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -8756,6 +11104,7 @@
               "type": "DataElement",
               "label": "Numerator",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2825219",
@@ -8767,8 +11116,8 @@
               ],
               "description": "The dividend of a fraction.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8789,11 +11138,12 @@
               "type": "DataElement",
               "label": "OccurrenceTime",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The point in time or span of time in which something happens.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8819,6 +11169,18 @@
                     "max": 1,
                     "constraints": [],
                     "type": "IdentifiableValue",
+                    "label": "primitive:date",
+                    "identifier": {
+                      "label": "date",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
                     "label": "shr.core:TimePeriod",
                     "identifier": {
                       "label": "TimePeriod",
@@ -8832,8 +11194,67 @@
             },
             {
               "type": "DataElement",
+              "label": "OrganizationalIdentifier",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Unique identifier of something or someone, assigned by an organization, and potentially effective for only a limited time period.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Identifier",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:string",
+                "identifier": {
+                  "label": "string",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:TimePeriod",
+                  "identifier": {
+                    "label": "TimePeriod",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.actor:Organization",
+                  "identifier": {
+                    "label": "Organization",
+                    "type": "Identifier",
+                    "namespace": "shr.actor"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
               "label": "Percentage",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0439165",
@@ -8845,20 +11266,32 @@
               ],
               "description": "A percentage value where 100.0 represents 100%.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
                 "type": "IdentifiableValue",
-                "label": "primitive:decimal",
+                "label": "shr.core:Quantity",
                 "identifier": {
-                  "label": "decimal",
+                  "label": "Quantity",
                   "type": "Identifier",
-                  "namespace": "primitive"
+                  "namespace": "shr.core"
                 }
               },
               "children": []
@@ -8867,11 +11300,12 @@
               "type": "DataElement",
               "label": "PeriodOfUse",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A period of time when a device, medication, or other therapy is used.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -8887,6 +11321,7 @@
               "type": "DataElement",
               "label": "PortionTotality",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "https://evs.nci.nih.gov/ftp1/CDISC/SDTM/:C99075",
@@ -8898,8 +11333,8 @@
               ],
               "description": "ObservationQualifier for anatomical location or specimen further detailing the portion or totality, which means arrangement of, or apportioning of an entity.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8909,6 +11344,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/PortionTotalityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -8926,6 +11362,7 @@
               "type": "DataElement",
               "label": "PostalCode",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1514254",
@@ -8937,8 +11374,8 @@
               ],
               "description": "A postal code designating a region defined by the postal service.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8959,6 +11396,7 @@
               "type": "DataElement",
               "label": "Priority",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0549179",
@@ -8970,8 +11408,8 @@
               ],
               "description": "An ordinal numbered priority where 1=highest priority, 2=second highest priority, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -8992,11 +11430,12 @@
               "type": "DataElement",
               "label": "QualitativeDateTime",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A point in time, described qualitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9006,6 +11445,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeDateTimeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9023,11 +11463,12 @@
               "type": "DataElement",
               "label": "QualitativeFrequency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The frequency of an event, described qualitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9037,6 +11478,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9054,11 +11496,12 @@
               "type": "DataElement",
               "label": "QualitativeLikelihood",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A qualitative (subjective) likelihood.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9068,6 +11511,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeLikelihoodVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9085,11 +11529,12 @@
               "type": "DataElement",
               "label": "Quantity",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A quantity with units.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9123,11 +11568,12 @@
               "type": "DataElement",
               "label": "Range",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "An interval defined by an upper and/or lower bound. One of the two bounds must be specified, and the lower bound must be less than the upper bound.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -9161,6 +11607,7 @@
               "type": "DataElement",
               "label": "Ratio",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0456603",
@@ -9172,8 +11619,8 @@
               ],
               "description": "A unit of measurement for the quotient of the amount of one entity to another.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -9207,6 +11654,7 @@
               "type": "DataElement",
               "label": "Reason",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0566251",
@@ -9218,8 +11666,8 @@
               ],
               "description": "The justification for an action or non-action, conclusion, opinion, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9251,6 +11699,18 @@
                       "type": "Identifier",
                       "namespace": "shr.core"
                     }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.condition:Condition",
+                    "identifier": {
+                      "label": "Condition",
+                      "type": "Identifier",
+                      "namespace": "shr.condition"
+                    }
                   }
                 ]
               },
@@ -9260,11 +11720,12 @@
               "type": "DataElement",
               "label": "SemiquantDuration",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The duration of an event, described semi-quantitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9274,6 +11735,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeDurationVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9291,11 +11753,12 @@
               "type": "DataElement",
               "label": "SemiquantFrequency",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The frequency of an event, described semi-quantitatively.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9305,6 +11768,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9322,11 +11786,12 @@
               "type": "DataElement",
               "label": "Setting",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Description of the place or type of surroundings where something is positioned or where an event takes place.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9336,6 +11801,40 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/SettingVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "SpecificType",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A code or description representing the concept represented by the instance at a specific level. For example, for a Condition, the concept is MTH#C0348080 (Condition) but the Value is the SpecificType, i.e. MTH#C0011849 (Diabetes Mellitus). For an observation, the SpecificType defines what is being observed, measured, or asked, as specifically as possible. The SpecificType should always align with the concept of the element, for example, a blood pressure observation can be coded as a sitting blood pressure or standing blood pressure, and may be from a different code system (e.g. LOINC versus MTH). In other cases, the SpecificType is the specific question being asked, or the specific goal being pursued.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/SpecificTypeVS",
+                    "bindingStrength": "PREFERRED",
                     "path": ""
                   }
                 ],
@@ -9353,6 +11852,7 @@
               "type": "DataElement",
               "label": "State",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1552743",
@@ -9364,8 +11864,8 @@
               ],
               "description": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (i.e. US 2 letter state codes). (Source: HL7 FHIR).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9386,6 +11886,7 @@
               "type": "DataElement",
               "label": "Statistic",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2828391",
@@ -9397,8 +11898,8 @@
               ],
               "description": "A quantity that represents a statistic, e.g. maximum, minimum, mean, median, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -9427,11 +11928,12 @@
               "type": "DataElement",
               "label": "StatisticType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The type of statistic that is represented by the value.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9441,6 +11943,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/StatisticTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9458,6 +11961,7 @@
               "type": "DataElement",
               "label": "Substance",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0439861",
@@ -9469,8 +11973,8 @@
               ],
               "description": "Any matter of defined composition that has discrete existence, whose origin may be biological, mineral or chemical.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9491,6 +11995,7 @@
               "type": "DataElement",
               "label": "Summary",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1706244",
@@ -9502,8 +12007,8 @@
               ],
               "description": "A shortened version of an item of information, containing only the main points.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9524,6 +12029,7 @@
               "type": "DataElement",
               "label": "TimePeriod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1948053",
@@ -9535,8 +12041,8 @@
               ],
               "description": "A period of time defined by a start and end time, date, or year.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -9570,6 +12076,7 @@
               "type": "DataElement",
               "label": "TimePeriodEnd",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1522314",
@@ -9581,21 +12088,41 @@
               ],
               "description": "The time at which something is to end or did end.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
                 "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:dateTime",
-                "identifier": {
-                  "label": "dateTime",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:dateTime",
+                    "identifier": {
+                      "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:date",
+                    "identifier": {
+                      "label": "date",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  }
+                ]
               },
               "children": []
             },
@@ -9603,6 +12130,7 @@
               "type": "DataElement",
               "label": "TimePeriodStart",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1301880",
@@ -9614,21 +12142,41 @@
               ],
               "description": "The time at which something is to take effect, start, or did start.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
                 "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:dateTime",
-                "identifier": {
-                  "label": "dateTime",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:dateTime",
+                    "identifier": {
+                      "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:date",
+                    "identifier": {
+                      "label": "date",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  }
+                ]
               },
               "children": []
             },
@@ -9636,11 +12184,12 @@
               "type": "DataElement",
               "label": "Title",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A distinguishing word or group of words naming an item.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9661,11 +12210,12 @@
               "type": "DataElement",
               "label": "UnitedStatesAddress",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "An address for a place in the USA, conforming to US mail postal conventions. (Source: HL7 FHIR).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -9715,6 +12265,7 @@
               "type": "DataElement",
               "label": "UnitedStatesState",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3148680",
@@ -9726,8 +12277,8 @@
               ],
               "description": "A state or territory in the USA expressed by 2-letter US Postal code.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -9743,11 +12294,12 @@
               "type": "DataElement",
               "label": "Units",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Code for the unit of measure of the quantity.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9757,6 +12309,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/ucum-units",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9774,11 +12327,12 @@
               "type": "DataElement",
               "label": "UpperBound",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A measured or measurable amount with units that is known to be bounded from above by the quantity represented.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -9807,11 +12361,12 @@
               "type": "DataElement",
               "label": "UpperBoundType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Indicates the actual value is lt (<) or lte (<=) the given value.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9821,6 +12376,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/UpperBoundTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -9838,6 +12394,7 @@
               "type": "DataElement",
               "label": "Version",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0333052",
@@ -9849,8 +12406,8 @@
               ],
               "description": "A string identifying the particular of form of something (such as a code system or software product) that is different in some way from another form of the same thing.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9869,58 +12426,9 @@
             },
             {
               "type": "DataElement",
-              "label": "Vocabulary",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A formal terminology system.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:uri",
-                "identifier": {
-                  "label": "uri",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "VocabularyVersion",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The version of the vocabulary being used, if applicable.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:string",
-                "identifier": {
-                  "label": "string",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "Volume",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0449468",
@@ -9932,8 +12440,8 @@
               ],
               "description": "The amount of three dimensional space occupied by an object or the capacity of a space or container.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -9966,6 +12474,7 @@
               "type": "DataElement",
               "label": "Width",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0487742",
@@ -9977,8 +12486,8 @@
               ],
               "description": "The measurement or extent of something from side to side.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10013,28 +12522,22 @@
           "label": "shr.demographics",
           "type": "Namespace",
           "description": "The SHR Demographics domain contains definitions that describe basic characteristics of the person of record, such as name, address, and date of birth. Elements in the demographics domains are used for unique identification and patient matching.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "AddressUse",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Describes how the address is used, in particular, as a dwelling (primary, secondary, temporary), a former address, mailing address, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10044,6 +12547,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/demographics/vs/AddressUseVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -10061,6 +12565,7 @@
               "type": "DataElement",
               "label": "AddressUsed",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0682130",
@@ -10072,8 +12577,8 @@
               ],
               "description": "An address used by for dwelling, work, or other purposes. May be a physical location or an address used only for deliveries, such as a PO box.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10129,6 +12634,7 @@
               "type": "DataElement",
               "label": "BirthSex",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C4086849",
@@ -10140,8 +12646,8 @@
               ],
               "description": "Administrative sex assigned at birth and recorded on birth certificate.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10151,6 +12657,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/us/core/ValueSet/us-core-birthsex",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -10168,11 +12675,12 @@
               "type": "DataElement",
               "label": "CountryOfIssue",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A country acting as an assuing authority for a document.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10193,11 +12701,12 @@
               "type": "DataElement",
               "label": "DriversLicenseNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Identifying information from a drivers license.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10243,6 +12752,7 @@
               "type": "DataElement",
               "label": "Ethnicity",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0015031",
@@ -10254,8 +12764,8 @@
               ],
               "description": "Indicator of Hispanic or Latino origin.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10265,6 +12775,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -10294,11 +12805,12 @@
               "type": "DataElement",
               "label": "EthnicityDetail",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Additional description of ethnicity.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10314,6 +12826,7 @@
                       {
                         "type": "ValueSetConstraint",
                         "valueset": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity",
+                        "bindingStrength": "REQUIRED",
                         "path": ""
                       }
                     ],
@@ -10332,6 +12845,7 @@
                       {
                         "type": "ValueSetConstraint",
                         "valueset": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
+                        "bindingStrength": "REQUIRED",
                         "path": ""
                       }
                     ],
@@ -10351,6 +12865,7 @@
               "type": "DataElement",
               "label": "FamilialRelationship",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0015608",
@@ -10362,8 +12877,8 @@
               ],
               "description": "The relationship of the subject to another person in the same (extended) family. May or may not be a blood relative (determined by value). Can be used to indicate there is no relation of the given type (e.g., no siblings), using the NonOccurrenceModifier.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10373,6 +12888,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -10435,11 +12951,12 @@
               "type": "DataElement",
               "label": "FathersName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The name of the father as it was or likely to have been recorded on the birth certificate of the subject; most likely the name of the father at the time of birth of the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10460,6 +12977,7 @@
               "type": "DataElement",
               "label": "HealthInsurance",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "HealthInsurance (http://ncimeta.nci.nih.gov:C0021682)",
@@ -10472,8 +12990,8 @@
               ],
               "description": "Health insurance coverage available (even if not used for payment for a given encounter).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10483,6 +13001,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/demographics/vs/InsuranceProviderTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -10525,11 +13044,12 @@
               "type": "DataElement",
               "label": "HomeTelephoneNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A telephone number associated with a person's residence.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -10568,11 +13088,12 @@
               "type": "DataElement",
               "label": "InsuranceMemberId",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Patient identifier at a healthcare provider, insurer, or other related organization.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10593,6 +13114,7 @@
               "type": "DataElement",
               "label": "MaritalStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0024819",
@@ -10604,8 +13126,8 @@
               ],
               "description": "The most recent marital status of a person.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10615,6 +13137,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/marital-status",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -10632,6 +13155,7 @@
               "type": "DataElement",
               "label": "MedicalInterpreterNeeded",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1442531",
@@ -10643,8 +13167,8 @@
               ],
               "description": "Whether the subject requires an interpreter to communicate with an English-speaking provider.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10678,6 +13202,7 @@
               "type": "DataElement",
               "label": "MothersMaidenName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0806887",
@@ -10689,8 +13214,8 @@
               ],
               "description": "The name of the mother as it was or likely to have been recorded on the birth certificate of the subject. This is most likely the name prior to marriage of the mother (aka the maiden name).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10711,6 +13236,7 @@
               "type": "DataElement",
               "label": "MultipleBirth",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0026753",
@@ -10722,8 +13248,8 @@
               ],
               "description": "Indication if the person was part of a multiple birth event.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10757,6 +13283,7 @@
               "type": "DataElement",
               "label": "MultipleBirthOrder",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:73771-8",
@@ -10768,8 +13295,8 @@
               ],
               "description": "Order of birth of the person in multiple birth event (if part of multiple birth).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10790,6 +13317,7 @@
               "type": "DataElement",
               "label": "PassportNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1549737",
@@ -10801,8 +13329,8 @@
               ],
               "description": "Indicator of citizenship and identity.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -10848,6 +13376,7 @@
               "type": "DataElement",
               "label": "PersonOfRecord",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1299487",
@@ -10866,8 +13395,8 @@
               ],
               "description": "Extended demographic information about the subject of this SHR.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -11094,6 +13623,7 @@
               "type": "DataElement",
               "label": "PlaceOfBirth",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0032040",
@@ -11105,8 +13635,8 @@
               ],
               "description": "The location of a birth event. There may be multiple entries, but a person has only one place of birth.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11127,6 +13657,7 @@
               "type": "DataElement",
               "label": "Race",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0034510",
@@ -11138,8 +13669,8 @@
               ],
               "description": "Subjective association of a person with a named category of humans sharing common history, traits, place of family origin, nationality, tribe, or other inherited background.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11149,6 +13680,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -11178,11 +13710,12 @@
               "type": "DataElement",
               "label": "RaceDetail",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Additional description of race or heritage.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11198,6 +13731,7 @@
                       {
                         "type": "ValueSetConstraint",
                         "valueset": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
+                        "bindingStrength": "REQUIRED",
                         "path": ""
                       }
                     ],
@@ -11216,6 +13750,7 @@
                       {
                         "type": "ValueSetConstraint",
                         "valueset": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity",
+                        "bindingStrength": "REQUIRED",
                         "path": ""
                       }
                     ],
@@ -11235,6 +13770,7 @@
               "type": "DataElement",
               "label": "SocialSecurityNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1301821",
@@ -11246,8 +13782,8 @@
               ],
               "description": "A US social security number (SSN).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11268,6 +13804,7 @@
               "type": "DataElement",
               "label": "StateOfIssue",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1547728",
@@ -11279,8 +13816,8 @@
               ],
               "description": "Issuing authority for a drivers license.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11301,6 +13838,7 @@
               "type": "DataElement",
               "label": "Telecom",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2986441",
@@ -11312,8 +13850,8 @@
               ],
               "description": "An electronic means of contacting an organization or individual.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11383,11 +13921,12 @@
               "type": "DataElement",
               "label": "TelecomNumberOrAddress",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A user name or other identifier on a telecommunication network, such as a telephone number (including country code and extension, if necessary), email address, or SkypeID.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11408,11 +13947,12 @@
               "type": "DataElement",
               "label": "TelecomQualifier",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Provides more information about the type and uses of the telecom address.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11422,6 +13962,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/contact-point-use",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -11439,11 +13980,12 @@
               "type": "DataElement",
               "label": "TelecomType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The type or channel of the communication, such as email or telephone. If an messaging app, such as Skype, specify other.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11453,6 +13995,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/contact-point-system",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -11470,11 +14013,12 @@
               "type": "DataElement",
               "label": "TelecomTypeOther",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Specification of the type of telecom channel, if the TelecomType is other.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -11495,6 +14039,7 @@
               "type": "DataElement",
               "label": "TelephoneNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1515258",
@@ -11506,8 +14051,8 @@
               ],
               "description": "A sequence of decimal digits (0-9) that is used for identifying a destination telephone line or other device in a telephone network.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -11522,8 +14067,9 @@
                   "constraints": [
                     {
                       "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/demographics/vs/TelephoneTypeVS",
-                      "path": "shr.core.CodeableConcept"
+                      "valueset": "http://hl7.org/fhir/ValueSet/contact-point-system",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -11540,11 +14086,12 @@
               "type": "DataElement",
               "label": "WorkTelephoneNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A telephone number associated with a person's residence.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -11585,27 +14132,21 @@
           "label": "shr.device",
           "type": "Namespace",
           "description": "The SHR Device domain contains definitions relating to devices used to treat the person of record, either in measurements and observations, durable medical equipment used by the patient, and device implants.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "Device",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A specific durable physical device used in diagnosis or treatment. The value is the coding for a type of device, for example, a CPAP machine. The same device might be used on multiple patients.",
               "grammarVersion": {
-                "major": 4,
+                "major": 5,
                 "minor": 0,
                 "patch": 0
               },
@@ -11651,10 +14192,11 @@
               "type": "DataElement",
               "label": "DeviceUdi",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Unique Device Identifier (UDI) Barcode string number for a device, assigned by the organization using the device.",
               "grammarVersion": {
-                "major": 4,
+                "major": 5,
                 "minor": 0,
                 "patch": 0
               },
@@ -11676,10 +14218,11 @@
               "type": "DataElement",
               "label": "DeviceUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A statement pertaining to the use of a device by a subject. May document the use of a device, or that the subject does not use a particular type of device.",
               "grammarVersion": {
-                "major": 4,
+                "major": 5,
                 "minor": 0,
                 "patch": 0
               },
@@ -11761,10 +14304,11 @@
               "type": "DataElement",
               "label": "DeviceUseStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A code representing the patient or other source's judgment about the state of the device used that this statement is about. Generally this will be active or completed.",
               "grammarVersion": {
-                "major": 4,
+                "major": 5,
                 "minor": 0,
                 "patch": 0
               },
@@ -11775,6 +14319,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/device-statement-status",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -11792,10 +14337,11 @@
               "type": "DataElement",
               "label": "Implanted",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether this device is implanted in the body.",
               "grammarVersion": {
-                "major": 4,
+                "major": 5,
                 "minor": 0,
                 "patch": 0
               },
@@ -11817,10 +14363,11 @@
               "type": "DataElement",
               "label": "VendorModelNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The model number of the device, assigned by the manufacturer or vendor.",
               "grammarVersion": {
-                "major": 4,
+                "major": 5,
                 "minor": 0,
                 "patch": 0
               },
@@ -11844,28 +14391,22 @@
           "label": "shr.encounter",
           "type": "Namespace",
           "description": "The SHR Encounter domain contains definitions that capture interactions between the person of record and healthcare providers, including inpatient, ambulatory care, and telecare.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "Encounter",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A statement about a planned or actual interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -11894,6 +14435,25 @@
                   }
                 },
                 {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/encounter-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Status",
+                  "identifier": {
+                    "label": "Status",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
                   "min": 0,
                   "max": 1,
                   "constraints": [],
@@ -11910,9 +14470,20 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.encounter:EncounterType",
+                  "label": "shr.encounter:EncounterClass",
                   "identifier": {
-                    "label": "EncounterType",
+                    "label": "EncounterClass",
+                    "type": "Identifier",
+                    "namespace": "shr.encounter"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.encounter:ServiceGiven",
+                  "identifier": {
+                    "label": "ServiceGiven",
                     "type": "Identifier",
                     "namespace": "shr.encounter"
                   }
@@ -12038,50 +14609,14 @@
             },
             {
               "type": "DataElement",
-              "label": "EncounterNonOccurrenceModifier",
+              "label": "EncounterClass",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "True if the encounter did not occur.",
+              "description": "The type of encounter, e.g., inpatient, outpatient, emergency, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "NonOccurrenceModifier",
-                  "type": "Identifier",
-                  "namespace": "shr.base"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "urn:tbd:ReasonEncounterDidNotHappenVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Reason",
-                  "identifier": {
-                    "label": "Reason",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "EncounterType",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The mode of interaction, whether inpatient, outpatient, or telecare.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12090,7 +14625,8 @@
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/encounter/vs/EncounterTypeVS",
+                    "valueset": "http://hl7.org/fhir/ValueSet/v3-ActEncounterCode",
+                    "bindingStrength": "EXTENSIBLE",
                     "path": ""
                   }
                 ],
@@ -12106,13 +14642,53 @@
             },
             {
               "type": "DataElement",
+              "label": "EncounterNonOccurrenceModifier",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "True if the encounter did not occur.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "NonOccurrenceModifier",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
+              "children": [
+                {
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "urn:tbd:ReasonEncounterDidNotHappenVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Reason",
+                  "identifier": {
+                    "label": "Reason",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
               "label": "EpisodeOfCareCompletion",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Denotes how and why an episode of care ended.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12122,6 +14698,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/encounter/vs/EpisodeOfCareCompletionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12139,6 +14716,7 @@
               "type": "DataElement",
               "label": "Facility",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1547538",
@@ -12150,8 +14728,8 @@
               ],
               "description": "Services and space and equipment provided for a particular purpose; a building or place that provides a particular service or is used for a particular industry. Could be a clinical site, community site, or a mobile facility.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12233,6 +14811,7 @@
               "type": "DataElement",
               "label": "FacilityName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3261404",
@@ -12244,8 +14823,8 @@
               ],
               "description": "The DBA (doing business as) or most commonly-used name for a facility.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12266,6 +14845,7 @@
               "type": "DataElement",
               "label": "FacilityType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1547726",
@@ -12277,8 +14857,8 @@
               ],
               "description": "The type of function performed at the facility.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12288,6 +14868,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/v3-ServiceDeliveryLocationRoleType",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12305,6 +14886,7 @@
               "type": "DataElement",
               "label": "ManagingOrganization",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0677351",
@@ -12316,8 +14898,8 @@
               ],
               "description": "The organization that manages the operation of an activity, facility, or service provision.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12338,6 +14920,7 @@
               "type": "DataElement",
               "label": "MobileFacility",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0231435",
@@ -12349,8 +14932,8 @@
               ],
               "description": "A facility that moves from place to place, such as Meals-On-Wheels.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12371,6 +14954,7 @@
               "type": "DataElement",
               "label": "PaymentSource",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0680269",
@@ -12382,8 +14966,8 @@
               ],
               "description": "The source of payment for the current encounter.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12399,11 +14983,12 @@
               "type": "DataElement",
               "label": "ProviderOrganization",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12424,6 +15009,7 @@
               "type": "DataElement",
               "label": "ReferralDate",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2735614",
@@ -12435,8 +15021,8 @@
               ],
               "description": "The date when the provider received a referral for service. A referral includes an oral, written, faxed or electronic request for services made by the client or on the client�s behalf.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12457,11 +15043,12 @@
               "type": "DataElement",
               "label": "ReferralSourceType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The type of person or entity that instigated the encounter.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12471,6 +15058,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/encounter/vs/ReferralSourceTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12486,13 +15074,40 @@
             },
             {
               "type": "DataElement",
+              "label": "ServiceGiven",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Indicates a medical service provided.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
               "label": "TreatmentCooperation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether the patient is undergoing treatment voluntarily, or under a legal order.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -12502,6 +15117,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/encounter/vs/TreatmentCooperationVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12521,23 +15137,17 @@
           "label": "shr.environment",
           "type": "Namespace",
           "description": "The SHR Environment domain contains definitions related to surroundings experienced by the person of record, including both the physical and sociological environments.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "AnimalExposure",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0238646",
@@ -12549,8 +15159,8 @@
               ],
               "description": "The type of animals or pets the subject is exposed to.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -12568,7 +15178,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/environment/vs/AnimalExposureVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -12594,11 +15205,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12607,6 +15218,7 @@
               "type": "DataElement",
               "label": "AnnualIncome",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0557163",
@@ -12618,13 +15230,13 @@
               ],
               "description": "The amount of earnings made by a family unit in one year, estimated or self-reported.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -12666,11 +15278,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12679,16 +15291,17 @@
               "type": "DataElement",
               "label": "CanAffordChildCare",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford child care?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -12700,6 +15313,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12727,11 +15341,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12740,16 +15354,17 @@
               "type": "DataElement",
               "label": "CanAffordClothing",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford clothing?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -12761,6 +15376,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12788,11 +15404,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12801,16 +15417,17 @@
               "type": "DataElement",
               "label": "CanAffordDentalCare",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford dental care?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -12822,6 +15439,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12849,11 +15467,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12862,16 +15480,17 @@
               "type": "DataElement",
               "label": "CanAffordFood",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford food?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -12883,6 +15502,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12910,11 +15530,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12923,16 +15543,17 @@
               "type": "DataElement",
               "label": "CanAffordHousing",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford housing?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -12944,6 +15565,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -12971,11 +15593,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -12984,16 +15606,17 @@
               "type": "DataElement",
               "label": "CanAffordMedication",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford medications?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13005,6 +15628,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13032,11 +15656,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -13045,16 +15669,17 @@
               "type": "DataElement",
               "label": "CanAffordTransportation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford transportation?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13066,6 +15691,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13093,11 +15719,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -13106,16 +15732,17 @@
               "type": "DataElement",
               "label": "CanAffordUtilities",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often can the subject afford utilities?",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13127,6 +15754,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13154,11 +15782,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -13167,16 +15795,17 @@
               "type": "DataElement",
               "label": "Coinhabitant",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A person living with the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13188,6 +15817,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/environment/vs/CoinhabitantVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13215,11 +15845,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -13228,6 +15858,7 @@
               "type": "DataElement",
               "label": "DomesticViolence",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0206073",
@@ -13239,13 +15870,13 @@
               ],
               "description": "Whether the subject experiences domestic violence.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13257,6 +15888,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13284,11 +15916,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -13309,16 +15941,17 @@
               "type": "DataElement",
               "label": "EmotionalSafety",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether the subject feels physically safe in the subject's home environment.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13330,6 +15963,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13357,11 +15991,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -13370,10 +16004,11 @@
               "type": "DataElement",
               "label": "EnvironmentalExposures",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -13399,11 +16034,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -13416,30 +16051,6 @@
                     "type": "Identifier",
                     "namespace": "shr.environment"
                   }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "RadiationExposure"
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "AllergenExposure"
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "AirQuality"
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "WaterQuality"
                 }
               ]
             },
@@ -13447,11 +16058,12 @@
               "type": "DataElement",
               "label": "ExposureMethod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How the exposure occurred, e.g. cutaneous contact, injection, ingestion, sexual contact, inhalation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -13461,6 +16073,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "urn:tbd:ExposureMethodVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13478,11 +16091,12 @@
               "type": "DataElement",
               "label": "ExposureReason",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Why the exposure occurred.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -13499,6 +16113,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/observation/vs/ExposureReasonVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13516,6 +16131,7 @@
               "type": "DataElement",
               "label": "ExposureSourceOrVector",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0012656",
@@ -13527,8 +16143,8 @@
               ],
               "description": "Where the substance originated. Vectors include animals (e.g., tick, mosquito, cats, livestock) capable of transmitting an infectious agent among vertebrates. Sources could include food, contaminated drinking water, air, radon gas in the home, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -13538,6 +16154,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "urn:tbd:ExposureSourceOrVectorVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13555,6 +16172,7 @@
               "type": "DataElement",
               "label": "ExposureToSubstance",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0332157",
@@ -13566,13 +16184,13 @@
               ],
               "description": "A statement about exposure to a substance, type of substance, or disease vector potentially affecting health, including pollutants, blood products, pets, recreational drugs, sexual transmitted diseases, foods, toxins, pathogens, or prenatal exposures to teratogens. Can be used to assert or deny such exposures.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "HistoryObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13606,23 +16224,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Category",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:GeneralizedLikelihood",
-                  "identifier": {
-                    "label": "GeneralizedLikelihood",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -13702,6 +16308,7 @@
               "type": "DataElement",
               "label": "FinancialSituation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0516918",
@@ -13713,8 +16320,8 @@
               ],
               "description": "Measures of the ability of the subject to obtain and pay for the necessities of life.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -13764,11 +16371,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -13919,16 +16526,17 @@
               "type": "DataElement",
               "label": "HomeEnvironmentRisk",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A risk experienced in the home environment.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -13940,6 +16548,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/environment/vs/HomeEnvironmentRiskVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -13967,11 +16576,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -13980,11 +16589,12 @@
               "type": "DataElement",
               "label": "HouseholdSituation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Information about the makeup of the household of the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -14010,46 +16620,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.environment:HouseholdSize",
-                  "identifier": {
-                    "label": "HouseholdSize",
-                    "type": "Identifier",
-                    "namespace": "shr.environment"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.environment:Coinhabitant",
-                  "identifier": {
-                    "label": "Coinhabitant",
-                    "type": "Identifier",
-                    "namespace": "shr.environment"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.environment:NumberOfDependents",
-                  "identifier": {
-                    "label": "NumberOfDependents",
-                    "type": "Identifier",
-                    "namespace": "shr.environment"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -14058,6 +16633,7 @@
               "type": "DataElement",
               "label": "HouseholdSize",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0000768",
@@ -14069,13 +16645,13 @@
               ],
               "description": "The number of people living together with mutual financial dependency. Besides the subject, the household size may include spouse or partner, dependent children including adopted and foster children, dependent parents, dependent siblings and other relatives, but not roommates, ex-spouses, non-dependent children, and unborn children. If the subject lives alone, the household size is 1.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14108,11 +16684,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -14121,16 +16697,17 @@
               "type": "DataElement",
               "label": "HousingSecurity",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether the subject is at-risk of losing their housing or in a stable housing situation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14142,6 +16719,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/environment/vs/ResourceStabilityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -14159,6 +16737,7 @@
               "type": "DataElement",
               "label": "IncomeSource",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0557162",
@@ -14170,13 +16749,13 @@
               ],
               "description": "Where the household income comes from.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14188,6 +16767,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/environment/vs/IncomeSourceVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -14215,11 +16795,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -14228,6 +16808,7 @@
               "type": "DataElement",
               "label": "IncomeStability",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1820459",
@@ -14239,13 +16820,13 @@
               ],
               "description": "Whether the subject regards his or her source of income as dependable.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14257,6 +16838,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/environment/vs/ResourceStabilityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -14284,11 +16866,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -14297,16 +16879,17 @@
               "type": "DataElement",
               "label": "NonCashBenefit",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Government benefits received by the focal subject, other than cash benefits.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14318,6 +16901,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/environment/vs/NonCashBenefitVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -14345,11 +16929,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -14370,6 +16954,7 @@
               "type": "DataElement",
               "label": "NumberOfDependents",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0557509",
@@ -14381,13 +16966,13 @@
               ],
               "description": "The number of dependents supported by the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14420,11 +17005,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -14433,16 +17018,17 @@
               "type": "DataElement",
               "label": "PhysicalSafety",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "How often the subject feels physically safe in the subject's home environment.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14454,6 +17040,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -14471,11 +17058,12 @@
               "type": "DataElement",
               "label": "SocialEnvironment",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Factors affecting the health of the subject in their daily living environment.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -14501,11 +17089,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -14585,16 +17173,17 @@
               "type": "DataElement",
               "label": "TransportationAvailability",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether the subject has reliable transportation to bring him or her to medical appointments and to get medications.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -14606,6 +17195,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -14625,41 +17215,28 @@
           "label": "shr.familyhistory",
           "type": "Namespace",
           "description": "The SHR Family History domain contains definitions related to the life, health, and genetics of persons related to the person of record.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": []
         },
         {
           "label": "shr.immunization",
           "type": "Namespace",
           "description": "The SHR Immunization domain contains definitions related to vaccinations, whether they are received, recommended, missing, or refused.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "Immunization",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0020971",
@@ -14671,10 +17248,17 @@
               ],
               "description": "A statement relating to a vaccination that was or was not administered to the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Action",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
               "children": [
                 {
                   "min": 1,
@@ -14691,13 +17275,20 @@
                 {
                   "min": 1,
                   "max": 1,
-                  "constraints": [],
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/no-immunization-reason",
+                      "bindingStrength": "REQUIRED",
+                      "path": "shr.core.Reason"
+                    }
+                  ],
                   "type": "IdentifiableValue",
-                  "label": "shr.immunization:ImmunizationNotGivenModifier",
+                  "label": "shr.base:NonOccurrenceModifier",
                   "identifier": {
-                    "label": "ImmunizationNotGivenModifier",
+                    "label": "NonOccurrenceModifier",
                     "type": "Identifier",
-                    "namespace": "shr.immunization"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -14749,6 +17340,7 @@
               "type": "DataElement",
               "label": "ImmunizationAdministered",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0580520",
@@ -14760,8 +17352,8 @@
               ],
               "description": "Represents an immunization that was administered to the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -14798,11 +17390,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.immunization:ImmunizationNotGivenModifier",
+                  "label": "shr.base:NonOccurrenceModifier",
                   "identifier": {
-                    "label": "ImmunizationNotGivenModifier",
+                    "label": "NonOccurrenceModifier",
                     "type": "Identifier",
-                    "namespace": "shr.immunization"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -14854,6 +17446,7 @@
               "type": "DataElement",
               "label": "ImmunizationNotGiven",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0580520",
@@ -14865,8 +17458,8 @@
               ],
               "description": "Represents an immunization that was not given.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -14886,11 +17479,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.immunization:ImmunizationNotGivenModifier",
+                  "label": "shr.base:NonOccurrenceModifier",
                   "identifier": {
-                    "label": "ImmunizationNotGivenModifier",
+                    "label": "NonOccurrenceModifier",
                     "type": "Identifier",
-                    "namespace": "shr.immunization"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -14940,47 +17533,9 @@
             },
             {
               "type": "DataElement",
-              "label": "ImmunizationNotGivenModifier",
-              "isEntry": false,
-              "concepts": [],
-              "description": "True, If the immunization was not given.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "NonOccurrenceModifier",
-                  "type": "Identifier",
-                  "namespace": "shr.base"
-                }
-              ],
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://hl7.org/fhir/ValueSet/no-immunization-reason",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Reason",
-                  "identifier": {
-                    "label": "Reason",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
               "label": "LotNumber",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1115660",
@@ -14992,8 +17547,8 @@
               ],
               "description": "A distinctive alpha-numeric identification code assigned by the manufacturer or distributor to a specific quantity of manufactured material or product within a batch.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -15014,6 +17569,7 @@
               "type": "DataElement",
               "label": "Vaccine",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1543322",
@@ -15025,8 +17581,8 @@
               ],
               "description": "A specific type or manufactured instance of a vaccine, a prophylactic or therapeutic preparation given to produce immune response to pathogenic organisms or substances.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -15036,13 +17592,14 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/vaccine-code",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
                 "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
+                "label": "shr.core:SpecificType",
                 "identifier": {
-                  "label": "CodeableConcept",
+                  "label": "SpecificType",
                   "type": "Identifier",
                   "namespace": "shr.core"
                 }
@@ -15078,6 +17635,7 @@
               "type": "DataElement",
               "label": "VaccineManufacturer",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1114744",
@@ -15089,8 +17647,8 @@
               ],
               "description": "The organization that produces the vaccine.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -15113,23 +17671,17 @@
           "label": "shr.lab",
           "type": "Namespace",
           "description": "The SHR Lab domain contains definitions for elements related to laboratory measurements.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "ChangeFlag",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1705241",
@@ -15141,8 +17693,8 @@
               ],
               "description": "Indicator of significant change (delta) from the last or previous measurement.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -15152,6 +17704,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lab/vs/ChangeFlagVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15169,11 +17722,12 @@
               "type": "DataElement",
               "label": "HIVScreeningTest",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "The result of an HIV Screening Test.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -15190,6 +17744,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lab/vs/HIVScreeningTestResultVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15209,15 +17764,16 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/lab/vs/HIVScreeningTestCodeVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "TestCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.lab"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -15226,11 +17782,12 @@
               "type": "DataElement",
               "label": "HIVScreeningTestRequest",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A request for a rapid HIV screening test.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -15248,15 +17805,16 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/lab/vs/HIVScreeningTestCodeVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "TestCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.lab"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -15265,11 +17823,12 @@
               "type": "DataElement",
               "label": "HIVSupplementalTest",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "The result of a supplement HIV test, following up an initial screening.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -15286,6 +17845,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lab/vs/HIVSupplementalTestResultVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15305,15 +17865,16 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/lab/vs/HIVSupplementalTestCodeVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "TestCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.lab"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -15322,11 +17883,12 @@
               "type": "DataElement",
               "label": "HIVSupplementalTestRequest",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A request for a confirmatory or additional test for HIV infection.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -15344,15 +17906,16 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/lab/vs/HIVSupplementalTestCodeVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "TestCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.lab"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -15361,6 +17924,7 @@
               "type": "DataElement",
               "label": "Interpretation",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0420833",
@@ -15372,8 +17936,8 @@
               ],
               "description": "A clinical interpretation of a measurement.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -15382,7 +17946,8 @@
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/TestInterpretationVS",
+                    "valueset": "http://hl7.org/fhir/ValueSet/observation-interpretation",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15398,41 +17963,14 @@
             },
             {
               "type": "DataElement",
-              "label": "ReferenceRange",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0883335",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0883335",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0883335;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The usual or acceptable range for a test result.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "TBD",
-                "text": "Range"
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "SpecimenType",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Kind of material that forms the specimen.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -15442,6 +17980,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/v2-0487",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15459,6 +17998,7 @@
               "type": "DataElement",
               "label": "Test",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0456984",
@@ -15470,8 +18010,8 @@
               ],
               "description": "A laboratory, radiologic, or other clinical test or measurement used to determine the presence, absence, or degree of a condition, or assess the function or health of an individual. This includes patient-generated data, such as pedometer readings.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -15487,20 +18027,18 @@
                   "max": 1,
                   "constraints": [
                     {
-                      "type": "TypeConstraint",
-                      "isA": {
-                        "_namespace": "shr.lab",
-                        "_name": "TestCode"
-                      },
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://hl7.org/fhir/ValueSet/observation-codes",
+                      "bindingStrength": "REQUIRED",
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -15517,23 +18055,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationMethod",
+                  "label": "shr.observation:Method",
                   "identifier": {
-                    "label": "ObservationMethod",
+                    "label": "Method",
                     "type": "Identifier",
                     "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:BodySite",
-                  "identifier": {
-                    "label": "BodySite",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -15572,23 +18098,11 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.lab:Interpretation",
-                  "identifier": {
-                    "label": "Interpretation",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:ReferenceRange",
+                  "label": "shr.observation:ReferenceRange",
                   "identifier": {
                     "label": "ReferenceRange",
                     "type": "Identifier",
-                    "namespace": "shr.lab"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -15619,46 +18133,9 @@
             },
             {
               "type": "DataElement",
-              "label": "TestCode",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The code for a laboratory, radiologic, and other clinical test or measurement that helps to determine the presence, absence, or degree of a condition, or assess the health of an individual.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "ObservationCode",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/observation-codes",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "TestMethod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1299991",
@@ -15670,13 +18147,13 @@
               ],
               "description": "The technique used to carry out a procedure, if not implicit in the test code.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "ObservationMethod",
+                  "label": "Method",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -15699,6 +18176,7 @@
               "type": "DataElement",
               "label": "TestRequest",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1273874",
@@ -15710,8 +18188,8 @@
               ],
               "description": "A record of a request (order) for a test to be performed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -15725,22 +18203,13 @@
                 {
                   "min": 1,
                   "max": 1,
-                  "constraints": [
-                    {
-                      "type": "TypeConstraint",
-                      "isA": {
-                        "_namespace": "shr.lab",
-                        "_name": "TestCode"
-                      },
-                      "path": ""
-                    }
-                  ],
+                  "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:ActionCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ActionCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.base"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -15756,19 +18225,21 @@
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
                   "max": 1,
                   "constraints": [],
                   "type": "ChoiceValue",
                   "value": [
                     {
-                      "min": 0,
+                      "min": 1,
                       "max": 1,
                       "constraints": [],
                       "type": "TBD",
                       "text": "Specimen"
                     },
                     {
+                      "min": 1,
+                      "max": 1,
                       "constraints": [],
                       "type": "IdentifiableValue",
                       "label": "shr.lab:SpecimenType",
@@ -15779,22 +18250,6 @@
                       }
                     }
                   ]
-                },
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://hl7.org/fhir/ValueSet/request-status",
-                      "path": "code"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.base:RequestStatus",
-                  "identifier": {
-                    "label": "RequestStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.base"
-                  }
                 }
               ]
             }
@@ -15804,23 +18259,17 @@
           "label": "shr.lifehistory",
           "type": "Namespace",
           "description": "The SHR Lifehistory domain contains definitions related to the course of events in the life of the person of record that might impact health, health risks, or future treatment.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "CongenitalAbnormality",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0000768",
@@ -15832,13 +18281,13 @@
               ],
               "description": "Any abnormality, genetic, anatomical, biochemical, evident at birth or during the neonatal period. Includes malformations, deformations, and chromosomal abnormalities.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -15850,6 +18299,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/CongenitalAbnormalitiesVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15877,11 +18327,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -15890,6 +18340,7 @@
               "type": "DataElement",
               "label": "EducationalAttainment",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0013658",
@@ -15901,13 +18352,13 @@
               ],
               "description": "Educational attainment or level of education of individuals.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -15919,6 +18370,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/EducationalAttainmentVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -15946,11 +18398,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -15959,6 +18411,7 @@
               "type": "DataElement",
               "label": "Employer",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1274022",
@@ -15970,8 +18423,8 @@
               ],
               "description": "A person or entity which hires the services of another.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16036,6 +18489,7 @@
               "type": "DataElement",
               "label": "Employment",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0014003",
@@ -16047,8 +18501,8 @@
               ],
               "description": "Engagement in an activity or service for profit, wages, salary, or as a service to others.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -16074,11 +18528,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -16123,6 +18577,7 @@
               "type": "DataElement",
               "label": "EmploymentStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0242271",
@@ -16134,8 +18589,8 @@
               ],
               "description": "Condition of employment including full- or part-time, temporary or permanent, and unemployment.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16145,6 +18600,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/EmploymentStatusVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16162,6 +18618,7 @@
               "type": "DataElement",
               "label": "MilitaryBranch",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2129058",
@@ -16173,8 +18630,8 @@
               ],
               "description": "The branch of the US military that the subject has served.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16184,6 +18641,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/USMilitaryBranchVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16201,6 +18659,7 @@
               "type": "DataElement",
               "label": "MilitaryService",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3714797",
@@ -16212,8 +18671,8 @@
               ],
               "description": "History of service in the US military.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -16239,77 +18698,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lifehistory:MilitaryStatus",
-                  "identifier": {
-                    "label": "MilitaryStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.lifehistory"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "MilitaryRank"
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lifehistory:MilitaryServiceDischargeStatus",
-                  "identifier": {
-                    "label": "MilitaryServiceDischargeStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.lifehistory"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lifehistory:MilitaryBranch",
-                  "identifier": {
-                    "label": "MilitaryBranch",
-                    "type": "Identifier",
-                    "namespace": "shr.lifehistory"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lifehistory:MilitaryServiceEra",
-                  "identifier": {
-                    "label": "MilitaryServiceEra",
-                    "type": "Identifier",
-                    "namespace": "shr.lifehistory"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lifehistory:ServiceConnectedDisability",
-                  "identifier": {
-                    "label": "ServiceConnectedDisability",
-                    "type": "Identifier",
-                    "namespace": "shr.lifehistory"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -16318,11 +18711,12 @@
               "type": "DataElement",
               "label": "MilitaryServiceDischargeStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How the subject was formally discharged from the US Military.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16332,6 +18726,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/MilitaryServiceDischargeStatusVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16349,11 +18744,12 @@
               "type": "DataElement",
               "label": "MilitaryServiceEra",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The time period of US military service.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16363,6 +18759,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/MilitaryServiceEraVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16380,6 +18777,7 @@
               "type": "DataElement",
               "label": "MilitaryStatus",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1550416",
@@ -16391,13 +18789,13 @@
               ],
               "description": "The current connection to the US military.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -16409,6 +18807,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/MilitaryStatusVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16426,6 +18825,7 @@
               "type": "DataElement",
               "label": "Occupation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0028811",
@@ -16437,13 +18837,13 @@
               ],
               "description": "The principal activity that a person does to earn money, specifying the job performed by the subject, for example, accountant, programmer analyst, patient care associate, staff nurse, etc.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -16455,6 +18855,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://www.bls.gov/soc/",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16482,11 +18883,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -16495,6 +18896,7 @@
               "type": "DataElement",
               "label": "PrenatalExposure",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0871747",
@@ -16506,8 +18908,8 @@
               ],
               "description": "Fetal contact with a dangerous substance via the mother.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -16523,7 +18925,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/lifehistory/vs/TeratogenVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -16570,11 +18973,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -16583,21 +18986,34 @@
               "type": "DataElement",
               "label": "ServiceConnectedDisability",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Percentage disability resulting from US Military Service.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
                 "type": "IdentifiableValue",
-                "label": "shr.core:Percentage",
+                "label": "shr.core:Quantity",
                 "identifier": {
-                  "label": "Percentage",
+                  "label": "Quantity",
                   "type": "Identifier",
                   "namespace": "shr.core"
                 }
@@ -16608,6 +19024,7 @@
               "type": "DataElement",
               "label": "Travel",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0040802",
@@ -16619,17 +19036,29 @@
               ],
               "description": "Trip to a foreign country or an area, particularly when a health risk is involved.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "HistoryObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
               ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:string",
+                "identifier": {
+                  "label": "string",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
               "children": [
                 {
                   "constraints": [
@@ -16646,11 +19075,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -16661,23 +19090,17 @@
           "label": "shr.medication",
           "type": "Namespace",
           "description": "The SHR Medication domain contains definitions related to medications taken, or not taken, by the person of record, both currently and in the past.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "AdditionalDoseInstruction",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1644714",
@@ -16689,8 +19112,8 @@
               ],
               "description": "Supplemental instructions - e.g. 'with meals'.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16700,6 +19123,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/additional-instructions-codes",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16717,6 +19141,7 @@
               "type": "DataElement",
               "label": "Adherence",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2364172",
@@ -16728,24 +19153,26 @@
               ],
               "description": "A statement of the ability and cooperation of the patient in taking medicine or supplement as recommended or prescribed. This includes correct timing, dosage, and frequency.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
                 {
-                  "min": 1,
-                  "max": 1,
+                  "min": 0,
                   "constraints": [],
                   "type": "ChoiceValue",
                   "value": [
                     {
-                      "min": 0,
+                      "min": 1,
+                      "max": 1,
                       "constraints": [],
                       "type": "TBD",
                       "text": "MedicationTreatment"
                     },
                     {
+                      "min": 1,
+                      "max": 1,
                       "constraints": [],
                       "type": "TBD",
                       "text": "SupplementTreatment"
@@ -16793,6 +19220,7 @@
               "type": "DataElement",
               "label": "AdherenceLevel",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1510802",
@@ -16804,8 +19232,8 @@
               ],
               "description": "The frequency that the stated treatment plan, prescription, or protocol is followed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16815,6 +19243,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16832,6 +19261,7 @@
               "type": "DataElement",
               "label": "AdministrationBodySite",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0229986",
@@ -16843,8 +19273,8 @@
               ],
               "description": "The anatomic site at which medical intervention is applied.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16865,6 +19295,7 @@
               "type": "DataElement",
               "label": "AdministrationMethod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1547585",
@@ -16876,8 +19307,8 @@
               ],
               "description": "Technique for administering medication.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16887,6 +19318,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/administration-method-codes",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -16904,11 +19336,12 @@
               "type": "DataElement",
               "label": "AmountOfMedication",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A standardized measure or discrete amount of medication serving as a reference for dosing or strength, for example, 1 tablet.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16929,11 +19362,12 @@
               "type": "DataElement",
               "label": "AmountPerDose",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The amount of medication taken at each dose, as a quantity or range.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -16969,11 +19403,12 @@
               "type": "DataElement",
               "label": "Brand",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "If the product is branded, and if so, the brand name of a product.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17007,11 +19442,12 @@
               "type": "DataElement",
               "label": "BrandName",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The marketing name for a brand name product",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17032,6 +19468,7 @@
               "type": "DataElement",
               "label": "Dosage",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0178602",
@@ -17043,8 +19480,8 @@
               ],
               "description": "The dosage of the medication as prescribed.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -17160,6 +19597,7 @@
               "type": "DataElement",
               "label": "DoseAsNeededIndicator",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1883728",
@@ -17171,8 +19609,8 @@
               ],
               "description": "Indicates that a drug or therapy should be used as often as the patient decides it is necessary.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17193,6 +19631,7 @@
               "type": "DataElement",
               "label": "DoseForm",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0013058",
@@ -17204,8 +19643,8 @@
               ],
               "description": "The form in which active and/or inert ingredient(s) are physically presented.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17215,6 +19654,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/medication-form-codes",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -17232,11 +19672,12 @@
               "type": "DataElement",
               "label": "DoseInstructionsText",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The directions (signetur) on the drug prescription or dispensing record.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17257,6 +19698,7 @@
               "type": "DataElement",
               "label": "Ingredient",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3176062",
@@ -17268,8 +19710,8 @@
               ],
               "description": "Specifies how many (or how much) of an ingredient there is in this Medication. For example, 250 mg per tablet is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17279,6 +19721,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/medication/vs/MedicationVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -17333,11 +19776,12 @@
               "type": "DataElement",
               "label": "IngredientAmount",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The amount of an ingredient in a medication.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17358,11 +19802,12 @@
               "type": "DataElement",
               "label": "IsActiveIngredient",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "True if the ingredient is an active ingredient in the medication.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17383,11 +19828,12 @@
               "type": "DataElement",
               "label": "MaximumDosePerTimePeriod",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The maximum amount of a medication to be taken in a given period of time.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -17421,6 +19867,7 @@
               "type": "DataElement",
               "label": "Medication",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0013227",
@@ -17432,8 +19879,8 @@
               ],
               "description": "A type of prescription drug or over-the-counter drug that is used to prevent, treat, or relieve symptoms of a disease or abnormal condition, but excluding vaccines.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17443,13 +19890,14 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/medication/vs/MedicationVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
                 "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
+                "label": "shr.core:SpecificType",
                 "identifier": {
-                  "label": "CodeableConcept",
+                  "label": "SpecificType",
                   "type": "Identifier",
                   "namespace": "shr.core"
                 }
@@ -17508,11 +19956,12 @@
               "type": "DataElement",
               "label": "MedicationAfterChange",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A medication taken, after the change.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17533,11 +19982,12 @@
               "type": "DataElement",
               "label": "MedicationBeforeChange",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The medication taken, prior to the change.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -17558,6 +20008,7 @@
               "type": "DataElement",
               "label": "MedicationChange",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0554834",
@@ -17569,8 +20020,8 @@
               ],
               "description": "Description of a modification or change of a medication or dosage.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -17633,11 +20084,12 @@
               "type": "DataElement",
               "label": "MedicationNotAdministered",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A record of a medication NOT administered. Recorded when deviating from the care plan.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -17715,11 +20167,12 @@
               "type": "DataElement",
               "label": "MedicationNotPrescribed",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "A record of a medication NOT prescribed. Recorded only when deviating from the normal expectation, care plan, or standard of care.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -17741,48 +20194,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.medication:MedicationNotPrescribedModifier",
+                  "label": "shr.base:NonOccurrenceModifier",
                   "identifier": {
-                    "label": "MedicationNotPrescribedModifier",
+                    "label": "NonOccurrenceModifier",
                     "type": "Identifier",
-                    "namespace": "shr.medication"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "MedicationNotPrescribedModifier",
-              "isEntry": false,
-              "concepts": [],
-              "description": "True, if the medication should not, or was not prescribed for a particular reason.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "RequestNotToPerformActionModifier",
-                  "type": "Identifier",
-                  "namespace": "shr.base"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/medication/vs/ReasonMedicationNotUsedVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Reason",
-                  "identifier": {
-                    "label": "Reason",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
+                    "namespace": "shr.base"
                   }
                 }
               ]
@@ -17791,11 +20207,12 @@
               "type": "DataElement",
               "label": "MedicationPrescription",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Report of a medication prescription.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -17821,34 +20238,27 @@
                 {
                   "constraints": [
                     {
-                      "type": "TypeConstraint",
-                      "isA": {
-                        "_namespace": "shr.medication",
-                        "_name": "MedicationNotPrescribedModifier"
-                      },
-                      "path": ""
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/medication/vs/ReasonMedicationNotUsedVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": "shr.core.Reason"
                     }
                   ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.base:RequestNotToPerformActionModifier",
-                  "identifier": {
-                    "label": "RequestNotToPerformActionModifier",
-                    "type": "Identifier",
-                    "namespace": "shr.base"
-                  }
+                  "type": "Incomplete"
                 },
                 {
                   "constraints": [
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://hl7.org/fhir/ValueSet/medication-request-status",
-                      "path": "code"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:RequestStatus",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "RequestStatus",
+                    "label": "Status",
                     "type": "Identifier",
                     "namespace": "shr.base"
                   }
@@ -17858,7 +20268,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://hl7.org/fhir/ValueSet/medication-request-priority",
-                      "path": "code"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -17921,13 +20332,48 @@
             },
             {
               "type": "DataElement",
+              "label": "MedicationRegimen",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0237125",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0237125",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0237125;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Use or application of over-the-counter and prescribed/recommended medications and infusions to meet guidelines for therapeutic action, safety, and schedule.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "children": [
+                {
+                  "min": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.medication:MedicationPrescription",
+                  "identifier": {
+                    "label": "MedicationPrescription",
+                    "type": "Identifier",
+                    "namespace": "shr.medication"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
               "label": "MedicationUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
-              "description": "Report of a medication used (or not used). Medication use is either reported, directly observed, or inferred from clinical events associated with orders, prescriptions written, pharmacy dispensings, procedural administrations, and other patient-reported information.",
+              "description": "Report of a medication actually being used (or not used). Medication use is either reported, directly observed, or inferred from clinical events associated with orders, prescriptions written, pharmacy dispensings, procedural administrations, and other patient-reported information.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -18009,11 +20455,12 @@
               "type": "DataElement",
               "label": "MedicationWasTaken",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Indicator of the certainty of whether the medication was taken by the patient.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18023,6 +20470,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/medication-statement-taken",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -18040,11 +20488,12 @@
               "type": "DataElement",
               "label": "NonAdherenceReason",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Reason for not following the stated treatment plan, prescription, or protocol.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18054,6 +20503,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/medication/vs/MedicationNonAdherenceReasonVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -18071,11 +20521,12 @@
               "type": "DataElement",
               "label": "NumberOfRepeatsAllowed",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "How many times the medication prescription can be refilled. This integer does NOT include the original order dispense. This means that if an order indicates dispense 30 tablets plus 3 repeats, then the order can be dispensed a total of 4 times and the patient can receive a total of 120 tablets.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18096,11 +20547,12 @@
               "type": "DataElement",
               "label": "OverTheCounter",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "True if the medication is available to consumers without a prescription.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18121,11 +20573,12 @@
               "type": "DataElement",
               "label": "QuantityPerDispense",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The amount that is to be dispensed for one fill.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18146,6 +20599,7 @@
               "type": "DataElement",
               "label": "RouteIntoBody",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0013153",
@@ -18157,8 +20611,8 @@
               ],
               "description": "The way a substance enters an organism after contact, particularly, the route of drug administration.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18168,6 +20622,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://hl7.org/fhir/ValueSet/route-codes",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -18185,11 +20640,12 @@
               "type": "DataElement",
               "label": "SupplyDuration",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18210,11 +20666,12 @@
               "type": "DataElement",
               "label": "TimingOfDoses",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "When doses of medication should be administered.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18230,11 +20687,12 @@
               "type": "DataElement",
               "label": "TypeOfChange",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether the change is a dose change, switch to a new medication, or discontinuation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18244,6 +20702,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/medication/vs/MedicationChangeTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -18263,28 +20722,56 @@
           "label": "shr.observation",
           "type": "Namespace",
           "description": "The SHR Observation domain contains basic definitions used to capture information about measurements, lab tests, and assessments.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
-              "label": "BooleanObservation",
-              "isEntry": true,
+              "label": "AssociatedStudy",
+              "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "An observation whose value is a quantity",
+              "description": "The clinical trial or other formal study related to this finding.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "RefValue",
+                "label": "reference to shr.base:Study",
+                "identifier": {
+                  "label": "Study",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "BodyStructureObservation",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1268086",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1268086",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1268086;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Observation of the existence (or non-existence) distinct anatomical or pathological morphological feature or organizational pattern, acquired or innate. Examples include tissue types, tumors, and wounds. The observation has a body site that allows the the structure to be located in the body. The observation identifier allows other observations of the same body structure to be related to QualitativeValueScaleVSthis observation and tracked over time.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -18297,13 +20784,20 @@
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/BodyStructureVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
                 "type": "IdentifiableValue",
-                "label": "primitive:boolean",
+                "label": "shr.core:CodeableConcept",
                 "identifier": {
-                  "label": "boolean",
+                  "label": "CodeableConcept",
                   "type": "Identifier",
-                  "namespace": "primitive"
+                  "namespace": "shr.core"
                 }
               },
               "children": []
@@ -18312,11 +20806,12 @@
               "type": "DataElement",
               "label": "ClinicallyRelevantTime",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The time or time period that the observation addresses. The clinically relevant time is not necessarily when the information is gathered or when a test is carried out, but for example, when a specimen was collected, or the time period referred to by the question. Use a TimePeriod for a measurement or specimen collection continued over a significant period of time (e.g. 24 hour Urine Sodium).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -18335,22 +20830,16 @@
             },
             {
               "type": "DataElement",
-              "label": "CodeableConceptObservation",
-              "isEntry": true,
+              "label": "DataAbsentReason",
+              "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "An observation whose value is a codeable concept",
+              "description": "Provides a reason why the value of the observation is missing, if it is expected (some observations are not expected to have a value).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
-              "basedOn": [
-                {
-                  "label": "Observation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
               "value": {
                 "min": 1,
                 "max": 1,
@@ -18367,22 +20856,68 @@
             },
             {
               "type": "DataElement",
-              "label": "HistoryObservation",
+              "label": "Evidence",
               "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "An observation that serves as evidence for some type of assessment.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "RefValue",
+                    "label": "reference to shr.observation:Observation",
+                    "identifier": {
+                      "label": "Observation",
+                      "type": "Identifier",
+                      "namespace": "shr.observation"
+                    }
+                  }
+                ]
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Manifestation",
+              "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
-                  "label": "History of previous events (http://ncimeta.nci.nih.gov:C2004062)",
+                  "label": "http://ncimeta.nci.nih.gov:C1457887",
                   "type": "Concept",
                   "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C2004062",
-                  "display": "History of previous events",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C2004062;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                  "code": "C1457887",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1457887;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "Captures some aspect of the life, health, or medical history of a subject.",
+              "description": "A complaint or observed indication that a person has a condition or disease. Some examples of symptoms are headache, fever, fatigue, nausea, vomiting, and pain.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -18392,27 +20927,301 @@
                   "namespace": "shr.observation"
                 }
               ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/observation/vs/ManifestationVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
               "children": [
                 {
-                  "min": 1,
                   "constraints": [
                     {
-                      "type": "IncludesCodeConstraint",
+                      "type": "CodeConstraint",
                       "code": {
-                        "label": "History of previous events (http://ncimeta.nci.nih.gov:C2004062)",
+                        "label": "null:symptom",
                         "type": "Concept",
-                        "system": "http://ncimeta.nci.nih.gov",
-                        "code": "C2004062",
-                        "display": "History of previous events",
-                        "url": "https://uts.nlm.nih.gov/metathesaurus.html#C2004062;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                        "system": null,
+                        "code": "symptom",
+                        "url": ""
                       },
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.condition:Severity",
+                  "identifier": {
+                    "label": "Severity",
+                    "type": "Identifier",
+                    "namespace": "shr.condition"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Method",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The method of the observation, for example, the specific imaging technical or assessment vehicle.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Observation",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1554188",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1554188",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1554188;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "An Observation represents evidence, both subjective and objective. Observation includes any information about a subject that results from an act of observing, measuring, or evaluation. The focus of an observation can include the subject's behavior, physiological state, health state, functional status, environment, exposures to substances, etc. An Observation contains information about the act of observing or measuring, and the result of the observation. The method of observing can vary widely, from questioning, physical examination, formal assessment vehicles, laboratory tests, imaging procedures, etc. Patient-reported information is also considered an observation, where subject and observer are the same individual.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Action",
+                  "type": "Identifier",
+                  "namespace": "shr.base"
+                }
+              ],
+              "value": {
+                "min": 0,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Quantity",
+                    "identifier": {
+                      "label": "Quantity",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [
+                      {
+                        "type": "ValueSetConstraint",
+                        "valueset": "http://standardhealthrecord.org/shr/observation/vs/ObservationResultVS",
+                        "bindingStrength": "EXAMPLE",
+                        "path": ""
+                      }
+                    ],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:string",
+                    "identifier": {
+                      "label": "string",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:boolean",
+                    "identifier": {
+                      "label": "boolean",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Range",
+                    "identifier": {
+                      "label": "Range",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Ratio",
+                    "identifier": {
+                      "label": "Ratio",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:time",
+                    "identifier": {
+                      "label": "time",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:dateTime",
+                    "identifier": {
+                      "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:TimePeriod",
+                    "identifier": {
+                      "label": "TimePeriod",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  }
+                ]
+              },
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/observation/vs/ObservationCategoryVS",
+                      "bindingStrength": "EXTENSIBLE",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:BodySite",
+                  "identifier": {
+                    "label": "BodySite",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Reason",
+                  "identifier": {
+                    "label": "Reason",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:AssociatedStudy",
+                  "identifier": {
+                    "label": "AssociatedStudy",
                     "type": "Identifier",
                     "namespace": "shr.observation"
                   }
@@ -18423,59 +21232,38 @@
                   "constraints": [
                     {
                       "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/observation/vs/NonLabObservationStatusVS",
-                      "path": "shr.core.CodeableConcept"
+                      "valueset": "http://hl7.org/fhir/ValueSet/observation-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationStatus",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "ObservationStatus",
+                    "label": "Status",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "Observation",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1554188",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1554188",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1554188;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "An act that is intended to result in new information about a subject. The focus of an observation can include the subject's behavior, physiological state, functional status, environment, exposures to substances, etc. The method of observing can be via direct questions, formal assessment vehicle, laboratory test, or imaging procedure.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "children": [
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
-                  "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 },
                 {
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/observation/vs/ObservationNotMadeReasonVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": "shr.core.Reason"
+                    }
+                  ],
+                  "type": "Incomplete"
+                },
+                {
                   "min": 0,
+                  "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.observation:Method",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Method",
                     "type": "Identifier",
                     "namespace": "shr.observation"
                   }
@@ -18485,35 +21273,11 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationReason",
+                  "label": "shr.base:AssertionNegationModifier",
                   "identifier": {
-                    "label": "ObservationReason",
+                    "label": "AssertionNegationModifier",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationNonOccurrenceModifier",
-                  "identifier": {
-                    "label": "ObservationNonOccurrenceModifier",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationStatus",
-                  "identifier": {
-                    "label": "ObservationStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -18532,9 +21296,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationMethod",
+                  "label": "shr.observation:DataAbsentReason",
                   "identifier": {
-                    "label": "ObservationMethod",
+                    "label": "DataAbsentReason",
                     "type": "Identifier",
                     "namespace": "shr.observation"
                   }
@@ -18555,286 +21319,9 @@
                   "min": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.actor:Participant",
+                  "label": "shr.observation:ReferenceRange",
                   "identifier": {
-                    "label": "Participant",
-                    "type": "Identifier",
-                    "namespace": "shr.actor"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Setting",
-                  "identifier": {
-                    "label": "Setting",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Location",
-                  "identifier": {
-                    "label": "Location",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationCategory",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A categorization of the observation according to how the observation was collected or its clinical area.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "ChoiceValue",
-                "value": [
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [
-                      {
-                        "type": "ValueSetConstraint",
-                        "valueset": "http://hl7.org/fhir/ValueSet/observation-category",
-                        "path": ""
-                      }
-                    ],
-                    "type": "IdentifiableValue",
-                    "label": "shr.core:CodeableConcept",
-                    "identifier": {
-                      "label": "CodeableConcept",
-                      "type": "Identifier",
-                      "namespace": "shr.core"
-                    }
-                  },
-                  {
-                    "min": 1,
-                    "max": 1,
-                    "constraints": [],
-                    "type": "IdentifiableValue",
-                    "label": "shr.core:CodeableConcept",
-                    "identifier": {
-                      "label": "CodeableConcept",
-                      "type": "Identifier",
-                      "namespace": "shr.core"
-                    }
-                  }
-                ]
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationCode",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A term from a controlled vocabulary that defines the data element (the question, not the answer) as specifically as possible. The specific code should always align with the concept of the element, but may be more specific. For example, the concept associated with medications is code for 'medication used', but the ObservationCode is the code for the particular medication used. For tests, ObservationCode identifies the specific test being performed, and for observations, the specific question being asked.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "ActionCode",
-                  "type": "Identifier",
-                  "namespace": "shr.base"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationMethod",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The method of the observation, for example, the specific imaging technical or assessment vehicle.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationNonOccurrenceModifier",
-              "isEntry": false,
-              "concepts": [],
-              "description": "True if the observation did not occcur, e.g., if a test was not performed or the assessment was not done, when it might otherwise be expected.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "NonOccurrenceModifier",
-                  "type": "Identifier",
-                  "namespace": "shr.base"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/observation/vs/ObservationNotMadeReasonVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Reason",
-                  "identifier": {
-                    "label": "Reason",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationQualifier",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1443279",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1443279",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1443279;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "A description of the conditions or context of an observation, for example, under sedation, fasting or post-exercise. Body position and body site are also qualifiers, but handled separately. A qualifier cannot modify the measurement type; for example, a fasting blood sugar is still a blood sugar.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationReason",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The reason for making the observation.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Reason",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              ],
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ObservationStatus",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A qualifier describing the stage or administrative state of the observation. If not given, it is assumed the status is final.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/observation-status",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "primitive:code",
-                "identifier": {
-                  "label": "code",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Panel",
-              "isEntry": true,
-              "concepts": [],
-              "description": "A group of related observations, usually (but not always) taken together, whose result is captured in a report. Typically the ObservationCategory and ObservationReason are not given for individual observations that are part of the panel, but rather given at the level of the panel itself. Typically, the panel and all its sub-observations share the same metadata (provenance).",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "children": [
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
-                  "identifier": {
-                    "label": "PanelCode",
+                    "label": "ReferenceRange",
                     "type": "Identifier",
                     "namespace": "shr.observation"
                   }
@@ -18842,94 +21329,6 @@
                 {
                   "min": 0,
                   "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ServiceCategory",
-                  "identifier": {
-                    "label": "ServiceCategory",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationReason",
-                  "identifier": {
-                    "label": "ObservationReason",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationNonOccurrenceModifier",
-                  "identifier": {
-                    "label": "ObservationNonOccurrenceModifier",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ReportStatus",
-                  "identifier": {
-                    "label": "ReportStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationMethod",
-                  "identifier": {
-                    "label": "ObservationMethod",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ClinicallyRelevantTime",
-                  "identifier": {
-                    "label": "ClinicallyRelevantTime",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.actor:Participant",
-                  "identifier": {
-                    "label": "Participant",
-                    "type": "Identifier",
-                    "namespace": "shr.actor"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "TBD",
-                  "text": "Specimen"
-                },
-                {
-                  "min": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
                   "label": "shr.lab:Interpretation",
@@ -18953,46 +21352,223 @@
                 },
                 {
                   "min": 0,
+                  "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.core:Setting",
+                  "label": "shr.observation:PanelMembers",
                   "identifier": {
-                    "label": "Setting",
+                    "label": "PanelMembers",
                     "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Location",
-                  "identifier": {
-                    "label": "Location",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
+                    "namespace": "shr.observation"
                   }
                 }
               ]
             },
             {
               "type": "DataElement",
-              "label": "PanelCode",
+              "label": "ObservationComponent",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "A term from a controlled vocabulary that defines the data element (the question, not the answer) as specifically as possible. The panel code provides the identity of the type of panel.",
+              "description": "A simplified observation consisting of a type code, value (or data absent reason), reference range, and interpretation. Can be used in place of an observation when a full observation cannot be mapped, for example, in the components of an observation. Note that although Status is required, the value is not mapped to FHIR and is essentially ignored.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
-              "basedOn": [
+              "value": {
+                "min": 0,
+                "max": 1,
+                "constraints": [],
+                "type": "ChoiceValue",
+                "value": [
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Quantity",
+                    "identifier": {
+                      "label": "Quantity",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [
+                      {
+                        "type": "ValueSetConstraint",
+                        "valueset": "http://standardhealthrecord.org/shr/observation/vs/ObservationResultVS",
+                        "bindingStrength": "EXAMPLE",
+                        "path": ""
+                      }
+                    ],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:CodeableConcept",
+                    "identifier": {
+                      "label": "CodeableConcept",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:string",
+                    "identifier": {
+                      "label": "string",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:boolean",
+                    "identifier": {
+                      "label": "boolean",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Range",
+                    "identifier": {
+                      "label": "Range",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:Ratio",
+                    "identifier": {
+                      "label": "Ratio",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:time",
+                    "identifier": {
+                      "label": "time",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "primitive:dateTime",
+                    "identifier": {
+                      "label": "dateTime",
+                      "type": "Identifier",
+                      "namespace": "primitive"
+                    }
+                  },
+                  {
+                    "min": 1,
+                    "max": 1,
+                    "constraints": [],
+                    "type": "IdentifiableValue",
+                    "label": "shr.core:TimePeriod",
+                    "identifier": {
+                      "label": "TimePeriod",
+                      "type": "Identifier",
+                      "namespace": "shr.core"
+                    }
+                  }
+                ]
+              },
+              "children": [
                 {
-                  "label": "ActionCode",
-                  "type": "Identifier",
-                  "namespace": "shr.base"
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:DataAbsentReason",
+                  "identifier": {
+                    "label": "DataAbsentReason",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.lab:Interpretation",
+                  "identifier": {
+                    "label": "Interpretation",
+                    "type": "Identifier",
+                    "namespace": "shr.lab"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:ReferenceRange",
+                  "identifier": {
+                    "label": "ReferenceRange",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ObservationQualifier",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1443279",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1443279",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1443279;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
+              "description": "A description of the conditions or context of an observation, for example, under sedation, fasting or post-exercise. Body position and body site are also qualifiers, but handled separately. A qualifier cannot modify the measurement type; for example, a fasting blood sugar is still a blood sugar.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
               "value": {
                 "min": 1,
                 "max": 1,
@@ -19009,13 +21585,14 @@
             },
             {
               "type": "DataElement",
-              "label": "QuantitativeObservation",
+              "label": "Panel",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
-              "description": "An observation whose value is a quantity",
+              "description": "A grouped set of related observations, frequently captured at the same time. An example is a complete blood count (CBC), with separate observations for hemoglobin, hematocrit, etc. Could represent the content of a diagnostic report, such as a pathology report. Typically the Category and Reason are not given for individual observations that are part of the panel, but rather given at the level of the panel itself. The panel and all its sub-observations share the same metadata (provenance).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -19025,73 +21602,84 @@
                   "namespace": "shr.observation"
                 }
               ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:Quantity",
-                "identifier": {
-                  "label": "Quantity",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ReportStatus",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The status of the report associated with this panel.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/diagnostic-report-status",
-                    "path": ""
+              "children": [
+                {
+                  "min": 0,
+                  "max": 0,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:DataAbsentReason",
+                  "identifier": {
+                    "label": "DataAbsentReason",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
                   }
-                ],
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:PanelMembers",
+                  "identifier": {
+                    "label": "PanelMembers",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "PanelMembers",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "PanelMembers represent the elements of a group of a related observations. Examples are the measurements that compose a complete blood count (CBC), or the elements of a pathology report. Each member is an independent observation, but the grouping reflects a composite lab order, shared specimen, or a single report author.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 0,
+                "constraints": [],
                 "type": "IdentifiableValue",
-                "label": "primitive:code",
+                "label": "shr.observation:Observation",
                 "identifier": {
-                  "label": "code",
+                  "label": "Observation",
                   "type": "Identifier",
-                  "namespace": "primitive"
+                  "namespace": "shr.observation"
                 }
               },
               "children": []
             },
             {
               "type": "DataElement",
-              "label": "ServiceCategory",
+              "label": "ReferenceRange",
               "isEntry": false,
-              "concepts": [],
-              "description": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0883335",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0883335",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0883335;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The usual or acceptable range for a test result.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
                 "min": 1,
                 "max": 1,
                 "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
+                "type": "TBD",
+                "text": "Range"
               },
               "children": []
             },
@@ -19099,6 +21687,7 @@
               "type": "DataElement",
               "label": "SocialHistory",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3714536",
@@ -19110,13 +21699,13 @@
               ],
               "description": "The external elements and conditions which surround, influence, and affect the life and development of the subject. Includes social conditions such as poverty, violence, bullying.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "HistoryObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -19129,39 +21718,39 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/observation/vs/NonLabObservationStatusVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationStatus",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "ObservationStatus",
+                    "label": "Status",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 },
                 {
-                  "min": 1,
                   "constraints": [
                     {
-                      "type": "IncludesCodeConstraint",
+                      "type": "CodeConstraint",
                       "code": {
-                        "label": "social history (http://hl7.org/fhir/observation-category:social-history)",
+                        "label": "social history (null:social-history)",
                         "type": "Concept",
-                        "system": "http://hl7.org/fhir/observation-category",
+                        "system": null,
                         "code": "social-history",
                         "display": "social history",
-                        "url": "http://hl7.org/fhir/observation-category#definition"
+                        "url": ""
                       },
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Category",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 }
               ]
@@ -19172,509 +21761,69 @@
           "label": "shr.oncology",
           "type": "Namespace",
           "description": "SHR implementation of ASCO requirements.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
-              "label": "BreastCancerReceptorStatus",
-              "isEntry": true,
-              "concepts": [],
-              "description": "Immunohistochemistry (IHC) assessment for estrogen receptor (ER) and progesterone receptor (PR) as well as IHC or in situ hybridization (ISH) determination of human epidermal growth factor receptor 2 (HER2) status",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Panel",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "urn:tbd:TBD",
-                        "type": "Concept",
-                        "system": "urn:tbd",
-                        "code": "TBD",
-                        "url": ""
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
-                  "identifier": {
-                    "label": "PanelCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:EstrogenReceptorStatus",
-                  "identifier": {
-                    "label": "EstrogenReceptorStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:ProgesteroneReceptorStatus",
-                  "identifier": {
-                    "label": "ProgesteroneReceptorStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:HumanEpiduralGrowthFactorReceptor2Status",
-                  "identifier": {
-                    "label": "HumanEpiduralGrowthFactorReceptor2Status",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "BreastCancerStage",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://loinc.org:21908-9",
-                  "type": "Concept",
-                  "system": "http://loinc.org",
-                  "code": "21908-9",
-                  "url": "http://s.details.loinc.org/LOINC/21908-9.html"
-                }
-              ],
-              "description": "The stage of breast cancer, assessed according to the standard established by American Joint Committee on Cancer (AJCC). TNM Stage Grouping which categorizes the progression of cancer using the Roman Numeral system. See Table 140 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "CodeableConceptObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.12",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:21908-9",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "21908-9",
-                        "url": "http://s.details.loinc.org/LOINC/21908-9.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
-                  "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:BreastTumorCategory",
-                  "identifier": {
-                    "label": "BreastTumorCategory",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:BreastNodeCategory",
-                  "identifier": {
-                    "label": "BreastNodeCategory",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:BreastMetastatisCategory",
-                  "identifier": {
-                    "label": "BreastMetastatisCategory",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:PostSurgeryIndicator",
-                  "identifier": {
-                    "label": "PostSurgeryIndicator",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "BreastMetastatisCategory",
+              "label": "BRCA1Variant",
               "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://loinc.org:59522-3",
-                  "type": "Concept",
-                  "system": "http://loinc.org",
-                  "code": "59522-3",
-                  "url": "http://s.details.loinc.org/LOINC/59522-3.html"
-                }
-              ],
-              "description": "Part of the TNM classification system representing metastases.  The system is used to describe the spread of cancer to other parts of the body. See Table 144 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "CodeableConceptObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.25",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:59522-3",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "59522-3",
-                        "url": "http://s.details.loinc.org/LOINC/59522-3.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
-                  "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "BreastNodeCategory",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://loinc.org:59525-6",
-                  "type": "Concept",
-                  "system": "http://loinc.org",
-                  "code": "59525-6",
-                  "url": "http://s.details.loinc.org/LOINC/59525-6.html"
-                }
-              ],
-              "description": "The presence of metastases in regional lymph nodes. TNM node category for staging derived from the American Joint Committee on Cancer. See Table 147 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "CodeableConceptObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.14",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:59525-6",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "59525-6",
-                        "url": "http://s.details.loinc.org/LOINC/59525-6.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
-                  "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "BreastTumorCategory",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://loinc.org:59528-0",
-                  "type": "Concept",
-                  "system": "http://loinc.org",
-                  "code": "59528-0",
-                  "url": "http://s.details.loinc.org/LOINC/59528-0.html"
-                }
-              ],
-              "description": "The TNM tumor category based on the tumor size (greatest dimension), based on criteria from the American Joint Committee on Cancer. See Table 152 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "CodeableConceptObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.13",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:59528-0",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "59528-0",
-                        "url": "http://s.details.loinc.org/LOINC/59528-0.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
-                  "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "Cellularity",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C4055283",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C4055283",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C4055283;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The percentage of cells in a sample that are cancerous",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "QuantitativeObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "EstrogenReceptorStatus",
-              "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
-              "description": "Estrogen receptor alpha is the predominant estrogen receptor expressed in breast tissue and is overexpressed in around 50% of breast carcinomas. ER status (positive=present or overexpressed; negative=absent) is a factor in determining prognosis and treatment options.",
+              "description": "Whether the patient has a mutation in the BRCA1 gene.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "ReceptorStatusObservation",
+                  "label": "GeneticVariant",
                   "type": "Identifier",
                   "namespace": "shr.oncology"
                 }
               ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
               "children": [
                 {
                   "constraints": [
                     {
                       "type": "CodeConstraint",
                       "code": {
-                        "label": "urn:tbd:TBD",
+                        "label": "http://www.genenames.org:BRCA1",
                         "type": "Concept",
-                        "system": "urn:tbd",
-                        "code": "TBD",
-                        "url": ""
+                        "system": "http://www.genenames.org",
+                        "code": "BRCA1",
+                        "url": "http://www.genenames.org"
                       },
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.oncology:GeneIdentifier",
                   "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://snomed.info/sct:23307004",
-                        "type": "Concept",
-                        "system": "http://snomed.info/sct",
-                        "code": "23307004",
-                        "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=23307004"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:Receptor",
-                  "identifier": {
-                    "label": "Receptor",
+                    "label": "GeneIdentifier",
                     "type": "Identifier",
                     "namespace": "shr.oncology"
                   }
@@ -19683,101 +21832,21 @@
             },
             {
               "type": "DataElement",
-              "label": "HumanEpiduralGrowthFactorReceptor2Status",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C3810543",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C3810543",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3810543;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "HER2 is a member of the human epidermal growth factor receptor family of proteins and is encoded by the ERBB2 oncogene. HER2 is overexpressed in 20-30% of breast tumors,10 and is associated with an aggressive clinical course and poor prognosis. HER2 status (positive=present or overexpressed; negative=absent) is a factor in determining prognosis and treatment options.",
+              "label": "BRCA2Variant",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Whether the patient has a mutation in the BRCA2 gene.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "ReceptorStatusObservation",
+                  "label": "GeneticVariant",
                   "type": "Identifier",
                   "namespace": "shr.oncology"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://ncimeta.nci.nih.gov:C3810543",
-                        "type": "Concept",
-                        "system": "http://ncimeta.nci.nih.gov",
-                        "code": "C3810543",
-                        "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3810543;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
-                  "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "urn:tbd:TBD",
-                        "type": "Concept",
-                        "system": "urn:tbd",
-                        "code": "TBD",
-                        "url": ""
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:Receptor",
-                  "identifier": {
-                    "label": "Receptor",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "LargestLymphNodeSize",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1285847",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1285847",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1285847;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "QuantitativeObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
                 }
               ],
               "value": {
@@ -19785,31 +21854,50 @@
                 "max": 1,
                 "constraints": [
                   {
-                    "type": "CodeConstraint",
-                    "code": {
-                      "label": "http://unitsofmeasure.org:mm",
-                      "type": "Concept",
-                      "system": "http://unitsofmeasure.org",
-                      "code": "mm",
-                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
-                    },
-                    "path": "shr.core.Units:shr.core.Coding"
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
                   }
                 ],
                 "type": "IdentifiableValue",
-                "label": "shr.core:Quantity",
+                "label": "shr.core:CodeableConcept",
                 "identifier": {
-                  "label": "Quantity",
+                  "label": "CodeableConcept",
                   "type": "Identifier",
                   "namespace": "shr.core"
                 }
               },
-              "children": []
+              "children": [
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "http://www.genenames.org:BRCA2",
+                        "type": "Concept",
+                        "system": "http://www.genenames.org",
+                        "code": "BRCA2",
+                        "url": "http://www.genenames.org"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:GeneIdentifier",
+                  "identifier": {
+                    "label": "GeneIdentifier",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
             },
             {
               "type": "DataElement",
-              "label": "MetastaticBreastCancerDiagnosis",
+              "label": "BreastCancer",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1446377",
@@ -19819,17 +21907,17 @@
                   "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1446377;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "A diagnosis of Stage IV breast cancer, cancer originating in the breast that has spread to other organs of the body, most often the bones, lungs, liver, or brain.",
+              "description": "A cancer originating in the tissues of the breast, and potentially spread to other organs of the body.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "Problem",
+                  "label": "Condition",
                   "type": "Identifier",
-                  "namespace": "shr.problem"
+                  "namespace": "shr.condition"
                 }
               ],
               "value": {
@@ -19838,7 +21926,8 @@
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/MetastaticBreastCancerDiagnosisVS",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/BreastCancerTypeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -19866,47 +21955,41 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:ProblemCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ProblemCategory",
+                    "label": "Category",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.base"
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
                   "max": 1,
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "Clinical stage IV (http://snomed.info/sct:2640006)",
-                        "type": "Concept",
-                        "system": "http://snomed.info/sct",
-                        "code": "2640006",
-                        "display": "Clinical stage IV",
-                        "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=2640006"
-                      },
+                      "type": "ValueSetConstraint",
+                      "valueset": "urn:oid:2.16.840.1.113883.11.20.11.12",
+                      "bindingStrength": "REQUIRED",
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:GradeOrStage",
+                  "label": "shr.condition:Stage",
                   "identifier": {
-                    "label": "GradeOrStage",
+                    "label": "Stage",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.condition"
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
                   "max": 1,
                   "constraints": [
                     {
                       "type": "TypeConstraint",
                       "isA": {
                         "_namespace": "shr.oncology",
-                        "_name": "PrimaryTumorBodySite"
+                        "_name": "PrimaryTumorSite"
                       },
                       "path": ""
                     }
@@ -19918,118 +22001,72 @@
                     "type": "Identifier",
                     "namespace": "shr.core"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "BreastCancerGeneticAnalysis",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The status of genes known or suspected to play a role in breast cancer risk, for example, the tumor suppressor genes, BRCA1 and BRCA2.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
                 {
-                  "min": 0,
-                  "max": 0,
+                  "label": "Panel",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
+                  "label": "shr.oncology:BRCA1Variant",
                   "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "BRCA1Variant",
                     "type": "Identifier",
-                    "namespace": "shr.base"
+                    "namespace": "shr.oncology"
                   }
                 },
                 {
-                  "constraints": [
-                    {
-                      "type": "BooleanConstraint",
-                      "value": true,
-                      "path": ""
-                    }
-                  ],
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:IncludeOnProblemList",
+                  "label": "shr.oncology:BRCA2Variant",
                   "identifier": {
-                    "label": "IncludeOnProblemList",
+                    "label": "BRCA2Variant",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.oncology"
                   }
                 }
               ]
             },
             {
               "type": "DataElement",
-              "label": "PercentageInSituCarcinoma",
-              "isEntry": false,
+              "label": "BreastCancerReceptorStatus",
+              "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
-              "description": "The percentage of the cancer that is in situ, as opposed to invading other tissues.",
+              "description": "Immunohistochemistry (IHC) assessment for estrogen receptor (ER) and progesterone receptor (PR) as well as IHC or in situ hybridization (ISH) determination of human epidermal growth factor receptor 2 (HER2) status",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Panel",
                   "type": "Identifier",
                   "namespace": "shr.observation"
-                }
-              ],
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "PostSurgeryIndicator",
-              "isEntry": false,
-              "concepts": [],
-              "description": "Indicator, when true, indicates the stage is reflects the tumor size extent and location after surgical removal. If missing, it is assumed the staging is not post-surgical.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:boolean",
-                "identifier": {
-                  "label": "boolean",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "PrimaryTumorBodySite",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The body site of the primary tumor.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "BodySite",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              ],
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ProgesteroneReceptorStatus",
-              "isEntry": true,
-              "concepts": [],
-              "description": "Progesterone receptor is expressed in 65% of breast carcinomas.13 PR status (positive=present or overexpressed; negative=absent) is a factor in determining prognosis and treatment options.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "ReceptorStatusObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.oncology"
                 }
               ],
               "children": [
@@ -20048,31 +22085,52 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://snomed.info/sct:61078009",
-                        "type": "Concept",
-                        "system": "http://snomed.info/sct",
-                        "code": "61078009",
-                        "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=61078009"
-                      },
-                      "path": ""
-                    }
-                  ],
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "TBD",
+                  "text": "Specimen"
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.oncology:Receptor",
+                  "label": "shr.oncology:EstrogenReceptorStatus",
                   "identifier": {
-                    "label": "Receptor",
+                    "label": "EstrogenReceptorStatus",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ProgesteroneReceptorStatus",
+                  "identifier": {
+                    "label": "ProgesteroneReceptorStatus",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:HumanEpiduralGrowthFactorReceptor2Status",
+                  "identifier": {
+                    "label": "HumanEpiduralGrowthFactorReceptor2Status",
                     "type": "Identifier",
                     "namespace": "shr.oncology"
                   }
@@ -20081,30 +22139,40 @@
             },
             {
               "type": "DataElement",
-              "label": "Receptor",
-              "isEntry": false,
+              "label": "CancerGrowthPotential",
+              "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
-                  "label": "http://ncimeta.nci.nih.gov:C0597357",
+                  "label": "Cancer Cell Growth (http://ncimeta.nci.nih.gov:C1516170)",
                   "type": "Concept",
                   "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0597357",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0597357;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                  "code": "C1516170",
+                  "display": "Cancer Cell Growth",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1516170;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "A protein located on the cell surface, or in the cytoplasm, that binds to a specific signaling factor, such as a hormone, antigen, or neurotransmitter, causing a conformational and functional change in the receptor molecule. The ligand-bound receptor then alters its interaction with target molecules, which leads to changes in cellular physiology through modification of the activity of one or more signal transduction pathways.",
+              "description": "Information relating to rate of cell growth or proportion of cancer cells within the tumor that are growing and dividing to form new cancer cells.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/ReceptorVS",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeValueScaleVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -20116,105 +22184,56 @@
                   "namespace": "shr.core"
                 }
               },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ReceptorIntensityScore",
-              "isEntry": false,
-              "concepts": [],
-              "description": "Part of the Allred scoring, based on the intensity of that staining, on a scale of 0 to 3.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:unsignedInt",
-                "identifier": {
-                  "label": "unsignedInt",
-                  "type": "Identifier",
-                  "namespace": "primitive"
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:Ki-67LabelingIndex",
+                  "identifier": {
+                    "label": "Ki-67LabelingIndex",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:S-PhaseFraction",
+                  "identifier": {
+                    "label": "S-PhaseFraction",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
                 }
-              },
-              "children": []
+              ]
             },
             {
               "type": "DataElement",
-              "label": "ReceptorPositivityPercentage",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The percentage of cells that test (stain) positive for the presence of a receptor.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:Percentage",
-                "identifier": {
-                  "label": "Percentage",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ReceptorProportionScore",
-              "isEntry": false,
-              "concepts": [],
-              "description": "Part of Allred scoring, based on the percentage of cells that stain for a receptor, on a scale of 0 to 5.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:unsignedInt",
-                "identifier": {
-                  "label": "unsignedInt",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ReceptorStatusObservation",
-              "isEntry": false,
+              "label": "CancerLymphaticInvolvement",
+              "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
-                  "label": "http://ncimeta.nci.nih.gov:C0449443",
+                  "label": "http://ncimeta.nci.nih.gov:C0746333",
                   "type": "Concept",
                   "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0449443",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0449443;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                  "code": "C0746333",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0746333;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "Refers to the presence or absence of specific receptor molecules on the surface of a cells in a specimen.",
+              "description": "Whether or not lymph nodes contain cancer cells.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -20226,6 +22245,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -20243,9 +22263,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.oncology:Receptor",
+                  "label": "shr.oncology:LymphaticSystemSubdivision",
                   "identifier": {
-                    "label": "Receptor",
+                    "label": "LymphaticSystemSubdivision",
                     "type": "Identifier",
                     "namespace": "shr.oncology"
                   }
@@ -20255,9 +22275,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.oncology:ReceptorPositivityPercentage",
+                  "label": "shr.oncology:LargestLymphNodeSize",
                   "identifier": {
-                    "label": "ReceptorPositivityPercentage",
+                    "label": "LargestLymphNodeSize",
                     "type": "Identifier",
                     "namespace": "shr.oncology"
                   }
@@ -20267,9 +22287,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.oncology:ReceptorProportionScore",
+                  "label": "shr.oncology:NumberOfLymphNodesInvolved",
                   "identifier": {
-                    "label": "ReceptorProportionScore",
+                    "label": "NumberOfLymphNodesInvolved",
                     "type": "Identifier",
                     "namespace": "shr.oncology"
                   }
@@ -20279,21 +22299,9 @@
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.oncology:ReceptorIntensityScore",
+                  "label": "shr.oncology:DegreeOfLymphaticInvolvement",
                   "identifier": {
-                    "label": "ReceptorIntensityScore",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:ReceptorTotalScore",
-                  "identifier": {
-                    "label": "ReceptorTotalScore",
+                    "label": "DegreeOfLymphaticInvolvement",
                     "type": "Identifier",
                     "namespace": "shr.oncology"
                   }
@@ -20302,51 +22310,529 @@
             },
             {
               "type": "DataElement",
-              "label": "ReceptorTotalScore",
+              "label": "Cellularity",
               "isEntry": false,
-              "concepts": [],
-              "description": "Part of the Allred scoring, the total of proportion and intensity scores, from 0 to 8.",
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C4055283",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C4055283",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C4055283;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Percentage of cells in a sample that are cancerous",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
                 "type": "IdentifiableValue",
-                "label": "primitive:unsignedInt",
+                "label": "shr.core:Quantity",
                 "identifier": {
-                  "label": "unsignedInt",
+                  "label": "Quantity",
                   "type": "Identifier",
-                  "namespace": "primitive"
+                  "namespace": "shr.core"
                 }
               },
               "children": []
             },
             {
               "type": "DataElement",
-              "label": "SizeOfGrossTumorBed",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "urn:tbd:TBD",
-                  "type": "Concept",
-                  "system": "urn:tbd",
-                  "code": "TBD",
-                  "url": ""
-                }
-              ],
-              "description": "The largest dimension of the gross tumor bed/fibrotic area.",
+              "label": "DegreeOfLymphaticInvolvement",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Assessment of how much cancer is in a lymph node.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/DegreeOfLymphaticInvolvementVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "EstrogenReceptorStatus",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Estrogen receptor alpha is the predominant estrogen receptor expressed in breast tissue and is overexpressed in around 50% of breast carcinomas. ER status (positive=present or overexpressed; negative=absent) is a factor in determining prognosis and treatment options.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ReceptorStatusObservation",
+                  "type": "Identifier",
+                  "namespace": "shr.oncology"
+                }
+              ],
+              "children": [
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "http://loinc.org:16112-5",
+                        "type": "Concept",
+                        "system": "http://loinc.org",
+                        "code": "16112-5",
+                        "url": "http://s.details.loinc.org/LOINC/16112-5.html"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "http://snomed.info/sct:23307004",
+                        "type": "Concept",
+                        "system": "http://snomed.info/sct",
+                        "code": "23307004",
+                        "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=23307004"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorType",
+                  "identifier": {
+                    "label": "ReceptorType",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "GeneIdentifier",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1706509",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1706509",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1706509;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A unique code for a gene, including protein coding genes, ncRNA genes and pseudogenes, to allow unambiguous communication, drawn from HUGO Gene Nomenclature Committee.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/GeneIdentifierVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "GeneticVariant",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0678941",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0678941",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0678941;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Whether the patient carries a mutation in a particular gene.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:GeneIdentifier",
+                  "identifier": {
+                    "label": "GeneIdentifier",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:Refseq",
+                  "identifier": {
+                    "label": "Refseq",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "HistologicGrade",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1511980",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1511980",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1511980;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The Elston Grade/Nottingham Score, representative of the aggressive potential of the tumor. Well differentiated (Grade 1) look similar to normal cells and are usually slow growing, while poorly differentiated cells (Grade 3) look very different than normal and are fast-growing.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamCombinedGradeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:TubuleFormationScore",
+                  "identifier": {
+                    "label": "TubuleFormationScore",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:NuclearPleomorphismScore",
+                  "identifier": {
+                    "label": "NuclearPleomorphismScore",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:MitoticCountScore",
+                  "identifier": {
+                    "label": "MitoticCountScore",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "HumanEpiduralGrowthFactorReceptor2Status",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C3810543",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C3810543",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3810543;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "HER2 is a member of the human epidermal growth factor receptor family of proteins and is encoded by the ERBB2 oncogene. HER2 is overexpressed in 20-30% of breast tumors,10 and is associated with an aggressive clinical course and poor prognosis. HER2 status (positive=present or overexpressed; negative=absent) is a factor in determining prognosis and treatment options.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ReceptorStatusObservation",
+                  "type": "Identifier",
+                  "namespace": "shr.oncology"
+                }
+              ],
+              "children": [
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "http://loinc.org:48676-1",
+                        "type": "Concept",
+                        "system": "http://loinc.org",
+                        "code": "48676-1",
+                        "url": "http://s.details.loinc.org/LOINC/48676-1.html"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "urn:tbd:TBD",
+                        "type": "Concept",
+                        "system": "urn:tbd",
+                        "code": "TBD",
+                        "url": ""
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorType",
+                  "identifier": {
+                    "label": "ReceptorType",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/oncology/vs/HER2MethodVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Method",
+                  "identifier": {
+                    "label": "Method",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Ki-67LabelingIndex",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C4049944",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C4049944",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C4049944;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Ki-67 is a protein phosphatase whose expression is strongly associated with cell proliferation and encoded by the MKI67 gene. The Ki67 labeling index is the fraction of Ki-67-positive cells to total cells in a tumor specimen and may be useful for determining prognosis with respect to survival and disease recurrence. The more positive cells there are, the more quickly they are dividing and forming new cells.\tReferenceRange: Low <10, Intermediate 10-20, >20 High",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "LargestLymphNodeSize",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1285847",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1285847",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1285847;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The largest dimension of the largest lymph node invaded by cancer cells.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -20379,28 +22865,21 @@
             },
             {
               "type": "DataElement",
-              "label": "TumorMargins",
+              "label": "LymphaticSystemSubdivision",
               "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1269830",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1269830",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1269830;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The edge or border of the tissue removed in cancer surgery. The margin is described as negative or clean when the pathologist finds no cancer cells at the edge of the tissue, suggesting that all of the cancer has been removed. The margin is described as positive or involved when the pathologist finds cancer cells at the edge of the tissue, suggesting that all of the cancer has not been removed.",
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A lymph node area or nodal group; a subdivision of the entire lymphatic system. For breast cancer, this includes 5 areas: internal mammary lymph nodes, axillary lymph nodes level I, II, and III, and the supraclavicular lymph nodes.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "BodySite",
                   "type": "Identifier",
-                  "namespace": "shr.observation"
+                  "namespace": "shr.core"
                 }
               ],
               "value": {
@@ -20409,7 +22888,8 @@
                 "constraints": [
                   {
                     "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/LymphSystemSubdivisionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -20425,8 +22905,1423 @@
             },
             {
               "type": "DataElement",
-              "label": "TumorMeasurements",
+              "label": "M-Stage",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://loinc.org:59522-3",
+                  "type": "Concept",
+                  "system": "http://loinc.org",
+                  "code": "59522-3",
+                  "url": "http://s.details.loinc.org/LOINC/59522-3.html"
+                }
+              ],
+              "description": "Part of the TNM classification system representing metastases.  The system is used to describe the spread of cancer to other parts of the body. See Table 144 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.25",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "MitoticCountScore",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://snomed.info/sct:371472000",
+                  "type": "Concept",
+                  "system": "http://snomed.info/sct",
+                  "code": "371472000",
+                  "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=371472000"
+                }
+              ],
+              "description": "How fast the tumor cells are growing and dividing, determined from the number of mitotic cells present. Scored 1 to 3, with 3 being the most mitotic cells.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "N-Stage",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://loinc.org:59525-6",
+                  "type": "Concept",
+                  "system": "http://loinc.org",
+                  "code": "59525-6",
+                  "url": "http://s.details.loinc.org/LOINC/59525-6.html"
+                }
+              ],
+              "description": "The presence of metastases in regional lymph nodes. TNM node category for staging derived from the American Joint Committee on Cancer. See Table 147 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.14",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "NeoplasmObservation",
               "isEntry": true,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Observation of a unusual growth, for example, a tumor. The body site allows the abnormality to be located and identified. The abnormality identifier allows the tumor to be tracked over time.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "BodyStructureObservation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/NeoplasmObservationVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Identifier",
+                  "identifier": {
+                    "label": "Identifier",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/oncology/vs/NeoplasmObservationMethodVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Method",
+                  "identifier": {
+                    "label": "Method",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "NuclearPleomorphismScore",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "How large and varied the nuclei of the tumor cells are. Scored 1 to 3, with 3 being the most pleomorphism.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/NuclearPleomorphismScoreVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "NumberOfLymphNodesInvolved",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A count of lymph nodes invaded by cancer cells of those examined.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "Count (http://unitsofmeasure.org:1)",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "1",
+                      "display": "Count",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "PercentageInSituCarcinoma",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The percentage of the cancer that is in situ, as opposed to invading other tissues.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "PrimaryTumorSite",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0475447",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0475447",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0475447;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The location of the primary tumor.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "BodySite",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              ],
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ProgesteroneReceptorStatus",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1514471",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1514471",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1514471;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Progesterone receptor is expressed in 65% of breast carcinomas. PR status (positive=present or overexpressed; negative=absent) is a factor in determining prognosis and treatment options.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ReceptorStatusObservation",
+                  "type": "Identifier",
+                  "namespace": "shr.oncology"
+                }
+              ],
+              "children": [
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "http://loinc.org:16113-3",
+                        "type": "Concept",
+                        "system": "http://loinc.org",
+                        "code": "16113-3",
+                        "url": "http://s.details.loinc.org/LOINC/16113-3.html"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:SpecificType",
+                  "identifier": {
+                    "label": "SpecificType",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "constraints": [
+                    {
+                      "type": "CodeConstraint",
+                      "code": {
+                        "label": "http://ncimeta.nci.nih.gov:C0034833",
+                        "type": "Concept",
+                        "system": "http://ncimeta.nci.nih.gov",
+                        "code": "C0034833",
+                        "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0034833;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorType",
+                  "identifier": {
+                    "label": "ReceptorType",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "Progression",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0449258",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0449258",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0449258;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A finding related to the current trend of a disease. This concept is most often used for chronic and incurable diseases where the status and trendline of the disease is an important determinant of therapy and prognosis. The specific disorder being evaluated must be cited in the AssessmentFocus as a reference to a Condition.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Assessment",
+                  "type": "Identifier",
+                  "namespace": "shr.assessment"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/SubjectiveProgressionVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "constraints": [
+                    {
+                      "type": "IncludesCodeConstraint",
+                      "code": {
+                        "label": "Progression (http://ncimeta.nci.nih.gov:C0421176)",
+                        "type": "Concept",
+                        "system": "http://ncimeta.nci.nih.gov",
+                        "code": "C0421176",
+                        "display": "Progression",
+                        "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0421176;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                      },
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.base:Category",
+                  "identifier": {
+                    "label": "Category",
+                    "type": "Identifier",
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.assessment:AssessmentFocus",
+                  "identifier": {
+                    "label": "AssessmentFocus",
+                    "type": "Identifier",
+                    "namespace": "shr.assessment"
+                  }
+                },
+                {
+                  "min": 0,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/oncology/vs/ProgressionEvidenceTypeVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:Evidence",
+                  "identifier": {
+                    "label": "Evidence",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ReceptorAllredTotalScore",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Part of the Allred scoring, the total of proportion and intensity scores, from 0 to 8.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ReceptorIntensityScore",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Part of the Allred scoring, based on the intensity of that staining, on a scale of 0 to 3.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ReceptorPositivityPercentage",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The percentage of cells that test (stain) positive for the presence of a receptor.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ReceptorProportionScore",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Part of Allred scoring, based on the percentage of cells that stain for a receptor, on a scale of 0 to 5.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ReceptorStatusObservation",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0449443",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0449443",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0449443;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "Refers to the presence or absence of specific receptor molecules on the surface of a cells in a specimen.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorType",
+                  "identifier": {
+                    "label": "ReceptorType",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorPositivityPercentage",
+                  "identifier": {
+                    "label": "ReceptorPositivityPercentage",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorAllredTotalScore",
+                  "identifier": {
+                    "label": "ReceptorAllredTotalScore",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorProportionScore",
+                  "identifier": {
+                    "label": "ReceptorProportionScore",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:ReceptorIntensityScore",
+                  "identifier": {
+                    "label": "ReceptorIntensityScore",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ReceptorType",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0597357",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0597357",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0597357;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "A protein located on the cell surface, or in the cytoplasm, that binds to a specific signaling factor, such as a hormone, antigen, or neurotransmitter, causing a conformational and functional change in the receptor molecule. The ligand-bound receptor then alters its interaction with target molecules, which leads to changes in cellular physiology through modification of the activity of one or more signal transduction pathways.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/ReceptorVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "Refseq",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The Reference Sequence (RefSeq) collection provides a comprehensive, integrated, non-redundant, well-annotated set of sequences, including genomic DNA, transcripts, and proteins. RefSeq sequences form a foundation for medical, functional, and diversity studies. They provide a stable reference for genome annotation, gene identification and characterization, mutation and polymorphism analysis (especially RefSeqGene records), expression studies, and comparative analyses.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "S-PhaseFraction",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C0812425",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C0812425",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0812425;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "An expression of the number of mitoses found in a stated number of cells. The S-phase fraction number tells you what percentage of cells in the tissue sample are in the process of copying their genetic information (DNA). This S-phase, short for synthesis phase, happens just before a cell divides into two new cells. ReferenceRange: Low <6, Intermediate 6-10, >10 High.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:%",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "%",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "SizeOfGrossTumorBed",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The largest dimension of the gross tumor bed/fibrotic area.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:mm",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "mm",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "StagingSystem",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "What staging system are used ",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "primitive:string",
+                "identifier": {
+                  "label": "string",
+                  "type": "Identifier",
+                  "namespace": "primitive"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Version",
+                  "identifier": {
+                    "label": "Version",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "StagingTiming",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Indicates when the staging was done, in terms of treatment landmarks, for example, at diagnosis (clinical), at surgery(pathologic), after treatment (post-neoadjuvant), at entry to a clinical trial, or at recurrence.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/StagingTimeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "T-Stage",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://loinc.org:59528-0",
+                  "type": "Concept",
+                  "system": "http://loinc.org",
+                  "code": "59528-0",
+                  "url": "http://s.details.loinc.org/LOINC/59528-0.html"
+                }
+              ],
+              "description": "The size and extent of the primary tumor (greatest dimension), based on criteria from the American Joint Committee on Cancer. See Table 152 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.13",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "TNMStage",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://loinc.org:21908-9",
+                  "type": "Concept",
+                  "system": "http://loinc.org",
+                  "code": "21908-9",
+                  "url": "http://s.details.loinc.org/LOINC/21908-9.html"
+                }
+              ],
+              "description": "The stage of a cancer, assessed according to the standard established by American Joint Committee on Cancer (AJCC). TNM Stage Grouping categorizes the progression of cancer using the Roman Numeral system. See Table 140 in HL7 CDA® R2 Implementation Guide: Clinical Oncology Treatment Plan and Summary, Release 1 - US Realm",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "urn:oid:2.16.840.1.113883.11.20.11.12",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:StagingSystem",
+                  "identifier": {
+                    "label": "StagingSystem",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:StagingTiming",
+                  "identifier": {
+                    "label": "StagingTiming",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:T-Stage",
+                  "identifier": {
+                    "label": "T-Stage",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:N-Stage",
+                  "identifier": {
+                    "label": "N-Stage",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.oncology:M-Stage",
+                  "identifier": {
+                    "label": "M-Stage",
+                    "type": "Identifier",
+                    "namespace": "shr.oncology"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ToxicReaction",
+              "isEntry": true,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "An adverse reaction to medication, radiation treatment, or other therapy, that causes grade 3 or 4 adverse reaction.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "AdverseReaction",
+                  "type": "Identifier",
+                  "namespace": "shr.adverse"
+                }
+              ],
+              "children": [
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/oncology/vs/ToxicReactionVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.adverse:AdverseEventGrade",
+                  "identifier": {
+                    "label": "AdverseEventGrade",
+                    "type": "Identifier",
+                    "namespace": "shr.adverse"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "TubuleFormationScore",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://snomed.info/sct:371470008",
+                  "type": "Concept",
+                  "system": "http://snomed.info/sct",
+                  "code": "371470008",
+                  "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=371470008"
+                }
+              ],
+              "description": "A comparison between structures formed by the tumor cells as opposed to those formed by normal cells. Scored 1 to 3 with 3 being the most abnormal.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/TubuleFormationScoreVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "TumorMarginDescription",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "Description of the edge or border of tumor in situ by radiologist or of removed tumor by pathologist.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/oncology/vs/TumorMarginDescriptionVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "TumorMargins",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [
+                {
+                  "label": "http://ncimeta.nci.nih.gov:C1269830",
+                  "type": "Concept",
+                  "system": "http://ncimeta.nci.nih.gov",
+                  "code": "C1269830",
+                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1269830;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                }
+              ],
+              "description": "The edge or border of the tissue removed in cancer surgery. The margin is described as negative or clean when the pathologist finds no cancer cells at the edge of the tissue, suggesting that all of the cancer has been removed. The margin is described as positive or involved when the pathologist finds cancer cells at the edge of the tissue, suggesting that all of the cancer has not been removed.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "TumorSecondaryDimensionSize",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "The longest perpendicular diameter of the primary tumor.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "ObservationComponent",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:mm",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "mm",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "TumorSize",
+              "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C4086369",
@@ -20436,53 +24331,50 @@
                   "url": "https://uts.nlm.nih.gov/metathesaurus.html#C4086369;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "Measurements and assessment of tumor, in situ via imaging, or of removed tumor. See CDISC Table 3.3.2",
+              "description": "Measurement of the longest diameter of a tumor, in situ or on a excised tumor. See CDISC Table 3.3.2",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "Panel",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
               ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://ncimeta.nci.nih.gov:C4086369",
-                        "type": "Concept",
-                        "system": "http://ncimeta.nci.nih.gov",
-                        "code": "C4086369",
-                        "url": "https://uts.nlm.nih.gov/metathesaurus.html#C4086369;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
-                  "identifier": {
-                    "label": "PanelCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:mm",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "mm",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
                   }
-                },
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
                 {
                   "min": 1,
                   "max": 1,
                   "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.oncology:TumorPrimaryDimensionSize",
-                  "identifier": {
-                    "label": "TumorPrimaryDimensionSize",
-                    "type": "Identifier",
-                    "namespace": "shr.oncology"
-                  }
+                  "type": "TBD",
+                  "text": "Specimen"
                 },
                 {
                   "min": 0,
@@ -20545,470 +24437,36 @@
                   }
                 }
               ]
-            },
-            {
-              "type": "DataElement",
-              "label": "TumorPrimaryDimensionSize",
-              "isEntry": true,
-              "concepts": [],
-              "description": "The longest diameter of the primary tumor.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "QuantitativeObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "CodeConstraint",
-                    "code": {
-                      "label": "http://unitsofmeasure.org:mm",
-                      "type": "Concept",
-                      "system": "http://unitsofmeasure.org",
-                      "code": "mm",
-                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
-                    },
-                    "path": "shr.core.Units:shr.core.Coding"
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:Quantity",
-                "identifier": {
-                  "label": "Quantity",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "TumorSecondaryDimensionSize",
-              "isEntry": true,
-              "concepts": [],
-              "description": "The longest perpendicular diameter of the primary tumor.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "QuantitativeObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "CodeConstraint",
-                    "code": {
-                      "label": "http://unitsofmeasure.org:mm",
-                      "type": "Concept",
-                      "system": "http://unitsofmeasure.org",
-                      "code": "mm",
-                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
-                    },
-                    "path": "shr.core.Units:shr.core.Coding"
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:Quantity",
-                "identifier": {
-                  "label": "Quantity",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
             }
           ]
         },
         {
-          "label": "shr.problem",
+          "label": "shr.procedure",
           "type": "Namespace",
-          "description": "The SHR Problem domain contains basic definitions used to capture information about problems, concerns, complaints, and disorders.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "description": "The SHR Procedure domain contains base definitions for interventions.",
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
-              "label": "Abatement",
+              "label": "Procedure",
               "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1880019",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1880019",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1880019;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The end, remission or resolution.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:GeneralizedTemporalContext",
-                "identifier": {
-                  "label": "GeneralizedTemporalContext",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "AcademicProblem",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0000873",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0000873",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0000873;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "A problem with learning or behavior in a learning environment.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Problem",
-                  "type": "Identifier",
-                  "namespace": "shr.problem"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "urn:tbd:AcademicProblemVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:BodySite",
-                  "identifier": {
-                    "label": "BodySite",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "Asplenia",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0600031",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0600031",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0600031;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "Congenital absence of spleen.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Problem",
-                  "type": "Identifier",
-                  "namespace": "shr.problem"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "CodeConstraint",
-                    "code": {
-                      "label": "http://snomed.info/sct:93030006",
-                      "type": "Concept",
-                      "system": "http://snomed.info/sct",
-                      "code": "93030006",
-                      "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=93030006"
-                    },
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ClinicalStatus",
-              "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
-              "description": "A flag indicating whether the problem is active or inactive, recurring, in remission, or resolved.",
+              "description": "An action that is or was performed on a patient. This can be a physical intervention like an operation, or less invasive like counseling or hypnotherapy.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/condition-clinical",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "primitive:code",
-                "identifier": {
-                  "label": "code",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Criticality",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "Criticality (http://ncimeta.nci.nih.gov:C3858539)",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C3858539",
-                  "display": "Criticality",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3858539;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "A clinical judgment of potential clinical harm, or seriousness, of a condition. When the worst case result is assessed to have a life-threatening or organ system threatening potential, it is considered to be of high criticality.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "primitive:code",
-                "identifier": {
-                  "label": "code",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "GradeOrStage",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0699749",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0699749",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0699749;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The stage or grade of a disease.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/problem/vs/GradeOrStageVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "IncludeOnProblemList",
-              "isEntry": false,
-              "concepts": [],
-              "description": "Whether or not to include this problem on the subject's current problem list.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:boolean",
-                "identifier": {
-                  "label": "boolean",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Injury",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C3263722",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C3263722",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3263722;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "Damage inflicted on the body by an external force.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "Problem",
+                  "label": "Action",
                   "type": "Identifier",
-                  "namespace": "shr.problem"
-                }
-              ],
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Setting",
-                  "identifier": {
-                    "label": "Setting",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Location",
-                  "identifier": {
-                    "label": "Location",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "Manifestation",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1457887",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1457887",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1457887;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "A complaint or observed (subjective) indication that a person has a condition or disease. Some examples of symptoms are headache, fever, fatigue, nausea, vomiting, and pain.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "CodeableConceptObservation",
-                  "type": "Identifier",
-                  "namespace": "shr.observation"
+                  "namespace": "shr.base"
                 }
               ],
               "children": [
@@ -21018,573 +24476,17 @@
                   "constraints": [
                     {
                       "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/core/vs/ManifestationVS",
-                      "path": "shr.core.CodeableConcept"
+                      "valueset": "http://hl7.org/fhir/ValueSet/event-status",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "ObservationCode",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Severity",
-                  "identifier": {
-                    "label": "Severity",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:BodySite",
-                  "identifier": {
-                    "label": "BodySite",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "MentalHealthProblem",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C1446377",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C1446377",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1446377;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "A problem relating to a person’s psychological and emotional well-being.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Problem",
-                  "type": "Identifier",
-                  "namespace": "shr.problem"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/problem/vs/DSMVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Onset",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0277793",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0277793",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0277793;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "The beginning or first appearance of a mental or physical disorder.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:GeneralizedTemporalContext",
-                "identifier": {
-                  "label": "GeneralizedTemporalContext",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Preexisting",
-              "isEntry": false,
-              "concepts": [],
-              "description": "If the problem or condition existed before the current episode of care.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "primitive:boolean",
-                "identifier": {
-                  "label": "boolean",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Problem",
-              "isEntry": true,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0033213",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0033213",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0033213;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "A statement about a disorder, abnormality, problem, injury, complaint, functionality, concern, illness, disease, ailment, sickness, affliction, upset, difficulty, disorder, symptom, or trouble. May be used to state the existence or non-existence of a problem.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:ProblemCategory",
-                  "identifier": {
-                    "label": "ProblemCategory",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
-                  "identifier": {
-                    "label": "NonOccurrenceModifier",
+                    "label": "Status",
                     "type": "Identifier",
                     "namespace": "shr.base"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:GeneralizedLikelihood",
-                  "identifier": {
-                    "label": "GeneralizedLikelihood",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:SupportingEvidenceQuality",
-                  "identifier": {
-                    "label": "SupportingEvidenceQuality",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:ClinicalStatus",
-                  "identifier": {
-                    "label": "ClinicalStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:IncludeOnProblemList",
-                  "identifier": {
-                    "label": "IncludeOnProblemList",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
-                  "identifier": {
-                    "label": "Onset",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:WhenClinicallyRecognized",
-                  "identifier": {
-                    "label": "WhenClinicallyRecognized",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Preexisting",
-                  "identifier": {
-                    "label": "Preexisting",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Abatement",
-                  "identifier": {
-                    "label": "Abatement",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:BodySite",
-                  "identifier": {
-                    "label": "BodySite",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Severity",
-                  "identifier": {
-                    "label": "Severity",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
-                  "identifier": {
-                    "label": "Criticality",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:GradeOrStage",
-                  "identifier": {
-                    "label": "GradeOrStage",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
-                  "identifier": {
-                    "label": "Manifestation",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "ProblemCategory",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A categorization of the problem using common clinical categories.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/problem/vs/ProblemCategoryVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "Severity",
-              "isEntry": false,
-              "concepts": [
-                {
-                  "label": "http://ncimeta.nci.nih.gov:C0392364",
-                  "type": "Concept",
-                  "system": "http://ncimeta.nci.nih.gov",
-                  "code": "C0392364",
-                  "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0392364;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-                }
-              ],
-              "description": "Degree of severity of a symptom, disorder, or problem.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/condition-severity",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "SupportingEvidenceQuality",
-              "isEntry": false,
-              "concepts": [],
-              "description": "An assessment of the quality and/or quantity of the source information that supports judgment.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/problem/vs/EvidenceQualityVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "WhenClinicallyRecognized",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The time at which a condition or problem was first identified in a healthcare context.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:GeneralizedTemporalContext",
-                "identifier": {
-                  "label": "GeneralizedTemporalContext",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            }
-          ]
-        },
-        {
-          "label": "shr.procedure",
-          "type": "Namespace",
-          "description": "The SHR Procedure domain contains base definitions for interventions.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
-          "children": [
-            {
-              "type": "DataElement",
-              "label": "Procedure",
-              "isEntry": false,
-              "concepts": [],
-              "description": "An action that is or was performed on a patient. This can be a physical intervention like an operation, or less invasive like counseling or hypnotherapy.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.procedure:ProcedureStatus",
-                  "identifier": {
-                    "label": "ProcedureStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.procedure"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
-                  "identifier": {
-                    "label": "NonOccurrenceModifier",
-                    "type": "Identifier",
-                    "namespace": "shr.base"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:OccurrenceTime",
-                  "identifier": {
-                    "label": "OccurrenceTime",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.procedure:ProcedureParticipant",
-                  "identifier": {
-                    "label": "ProcedureParticipant",
-                    "type": "Identifier",
-                    "namespace": "shr.procedure"
                   }
                 },
                 {
@@ -21598,86 +24500,8 @@
                     "type": "Identifier",
                     "namespace": "shr.encounter"
                   }
-                },
-                {
-                  "min": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Reason",
-                  "identifier": {
-                    "label": "Reason",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
                 }
               ]
-            },
-            {
-              "type": "DataElement",
-              "label": "ProcedureParticipant",
-              "isEntry": false,
-              "concepts": [],
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Participant",
-                  "type": "Identifier",
-                  "namespace": "shr.actor"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://hl7.org/fhir/ValueSet/v3-ParticipationType",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.actor:ParticipationType",
-                  "identifier": {
-                    "label": "ParticipationType",
-                    "type": "Identifier",
-                    "namespace": "shr.actor"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
-              "label": "ProcedureStatus",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A code specifying the state of the procedure. Generally this will be in-progress or completed state.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://hl7.org/fhir/ValueSet/event-status",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "primitive:code",
-                "identifier": {
-                  "label": "code",
-                  "type": "Identifier",
-                  "namespace": "primitive"
-                }
-              },
-              "children": []
             }
           ]
         },
@@ -21685,64 +24509,28 @@
           "label": "shr.sex",
           "type": "Namespace",
           "description": "The SHR Sex domain contains definitions related to the sexual health and behavior of the person of record.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
-            {
-              "type": "DataElement",
-              "label": "ContraceptiveMethod",
-              "isEntry": false,
-              "concepts": [],
-              "description": "A contraceptive method used by the subject.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
             {
               "type": "DataElement",
               "label": "ContraceptiveMethodRecommendation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "The contraceptive method(s) recommended or prescribed by a provider, after counseling and assessment. More than one method can be selected, if applicable. .",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "type": "Identifier"
+                  "label": "Recommendation",
+                  "type": "TBD"
                 }
               ],
               "value": {
@@ -21751,6 +24539,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -21791,8 +24580,109 @@
             },
             {
               "type": "DataElement",
-              "label": "ContraceptivesUsed",
+              "label": "ContraceptiveMethodUsed",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "A contraceptive method used by the subject.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Observation",
+                  "type": "Identifier",
+                  "namespace": "shr.observation"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": [
+                {
+                  "min": 0,
+                  "max": 1,
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodReasonVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:Reason",
+                  "identifier": {
+                    "label": "Reason",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "DataElement",
+              "label": "ContraceptiveNotUsedReason",
+              "isEntry": false,
+              "isAbstract": false,
+              "concepts": [],
+              "description": "If not using a method of contraception, why.",
+              "grammarVersion": {
+                "major": 5,
+                "minor": 0,
+                "patch": 0
+              },
+              "basedOn": [
+                {
+                  "label": "Reason",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveNotUsedReasonVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
+              "children": []
+            },
+            {
+              "type": "DataElement",
+              "label": "ContraceptiveUse",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0700589",
@@ -21802,19 +24692,38 @@
                   "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0700589;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
                 }
               ],
-              "description": "The method or methods of contraception used.",
+              "description": "Whether the subject uses contaceptives, and the method or methods of contraception used.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "BooleanObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
               ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
               "children": [
                 {
                   "min": 1,
@@ -21833,52 +24742,34 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
                   "min": 0,
                   "constraints": [],
                   "type": "IdentifiableValue",
-                  "label": "shr.sex:ContraceptiveMethod",
+                  "label": "shr.sex:ContraceptiveNotUsedReason",
                   "identifier": {
-                    "label": "ContraceptiveMethod",
+                    "label": "ContraceptiveNotUsedReason",
                     "type": "Identifier",
                     "namespace": "shr.sex"
                   }
                 },
                 {
-                  "min": 1,
-                  "max": 1,
+                  "min": 0,
                   "constraints": [],
-                  "type": "ChoiceValue",
-                  "value": [
-                    {
-                      "min": 0,
-                      "constraints": [],
-                      "type": "IdentifiableValue",
-                      "label": "shr.sex:ReasonForContraceptiveMethod",
-                      "identifier": {
-                        "label": "ReasonForContraceptiveMethod",
-                        "type": "Identifier",
-                        "namespace": "shr.sex"
-                      }
-                    },
-                    {
-                      "constraints": [],
-                      "type": "IdentifiableValue",
-                      "label": "shr.sex:ReasonForNotUsingContraceptive",
-                      "identifier": {
-                        "label": "ReasonForNotUsingContraceptive",
-                        "type": "Identifier",
-                        "namespace": "shr.sex"
-                      }
-                    }
-                  ]
+                  "type": "IdentifiableValue",
+                  "label": "shr.sex:ContraceptiveMethodUsed",
+                  "identifier": {
+                    "label": "ContraceptiveMethodUsed",
+                    "type": "Identifier",
+                    "namespace": "shr.sex"
+                  }
                 }
               ]
             },
@@ -21886,6 +24777,7 @@
               "type": "DataElement",
               "label": "CurrentPregnancyStatus",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0552579",
@@ -21897,17 +24789,36 @@
               ],
               "description": "Whether or not the subject is currently pregnant.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "BooleanObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
               ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [
+                  {
+                    "type": "ValueSetConstraint",
+                    "valueset": "http://standardhealthrecord.org/shr/core/vs/ThreeValueLogicVS",
+                    "bindingStrength": "REQUIRED",
+                    "path": ""
+                  }
+                ],
+                "type": "IdentifiableValue",
+                "label": "shr.core:CodeableConcept",
+                "identifier": {
+                  "label": "CodeableConcept",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
               "children": [
                 {
                   "constraints": [
@@ -21924,11 +24835,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -21937,11 +24848,12 @@
               "type": "DataElement",
               "label": "Dispensed",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether an item, such as a medication or device, was given to a subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -21962,6 +24874,7 @@
               "type": "DataElement",
               "label": "GenderIdentity",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0017249",
@@ -21973,13 +24886,13 @@
               ],
               "description": "Subjective personal perception of one's own gender, which can be male, female, a blend of both, or neither.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -21991,6 +24904,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/sex/vs/GenderIdentityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -22008,16 +24922,17 @@
               "type": "DataElement",
               "label": "IntercourseDifficulty",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
-              "description": "Problem with sexual intercourse.",
+              "description": "Condition affecting sexual intercourse.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -22029,6 +24944,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/sex/vs/IntercourseDifficultyVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -22046,6 +24962,7 @@
               "type": "DataElement",
               "label": "NumberOfLivingChildren",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C2229975",
@@ -22057,13 +24974,13 @@
               ],
               "description": "Number of living children.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -22084,11 +25001,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -22097,6 +25014,7 @@
               "type": "DataElement",
               "label": "NumberOfPreviousPregnancies",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0422807",
@@ -22108,13 +25026,13 @@
               ],
               "description": "Number of previous pregnancies.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -22135,11 +25053,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -22148,6 +25066,7 @@
               "type": "DataElement",
               "label": "NumberOfSexualPartnersPastYear",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0556468",
@@ -22159,13 +25078,13 @@
               ],
               "description": "Number of sexual partners in past year.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -22173,7 +25092,19 @@
               "value": {
                 "min": 1,
                 "max": 1,
-                "constraints": [],
+                "constraints": [
+                  {
+                    "type": "CodeConstraint",
+                    "code": {
+                      "label": "http://unitsofmeasure.org:1",
+                      "type": "Concept",
+                      "system": "http://unitsofmeasure.org",
+                      "code": "1",
+                      "url": "http://unitsofmeasure.org/ucum.html#section-Alphabetic-Index-By-Symbol"
+                    },
+                    "path": "shr.core.Units:shr.core.Coding"
+                  }
+                ],
                 "type": "IdentifiableValue",
                 "label": "shr.core:Quantity",
                 "identifier": {
@@ -22188,6 +25119,7 @@
               "type": "DataElement",
               "label": "PregnancyHistory",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0032967",
@@ -22199,8 +25131,8 @@
               ],
               "description": "Information about current and past pregnancies.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -22226,15 +25158,15 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
@@ -22246,7 +25178,7 @@
                   }
                 },
                 {
-                  "min": 1,
+                  "min": 0,
                   "max": 1,
                   "constraints": [],
                   "type": "IdentifiableValue",
@@ -22275,11 +25207,12 @@
               "type": "DataElement",
               "label": "PregnancyIntention",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Whether the subject or his/her partner has a plan or desire to either become pregnant or have a child in the next year/near future.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -22296,6 +25229,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/core/vs/ThreeValueLogicVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -22323,62 +25257,25 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
             },
             {
               "type": "DataElement",
-              "label": "ReasonForContraceptiveMethod",
-              "isEntry": false,
-              "concepts": [],
-              "description": "If using particular method of methods of contraception, why",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Reason",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodReasonVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
               "label": "ReasonForNotRecommendingContraceptive",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "If not using a method of contraception, why.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -22388,44 +25285,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveNotUsedReasonVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": []
-            },
-            {
-              "type": "DataElement",
-              "label": "ReasonForNotUsingContraceptive",
-              "isEntry": false,
-              "concepts": [],
-              "description": "If not using a method of contraception, why.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "Reason",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveNotUsedReasonVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -22443,6 +25303,7 @@
               "type": "DataElement",
               "label": "SexualActivity",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0241028",
@@ -22454,13 +25315,13 @@
               ],
               "description": "Characterization of the sexual activity of the subject.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -22472,6 +25333,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/sex/vs/SexualActivityVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -22501,11 +25363,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -22514,6 +25376,7 @@
               "type": "DataElement",
               "label": "SexualBehavior",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C1314687",
@@ -22525,8 +25388,8 @@
               ],
               "description": "Experience with sexual intercourse.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -22552,11 +25415,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -22599,11 +25462,12 @@
               "type": "DataElement",
               "label": "SexualIdentity",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [],
               "description": "Information on gender identity and sexual orientation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -22629,35 +25493,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:PanelCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "PanelCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.sex:GenderIdentity",
-                  "identifier": {
-                    "label": "GenderIdentity",
-                    "type": "Identifier",
-                    "namespace": "shr.sex"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.sex:SexualOrientation",
-                  "identifier": {
-                    "label": "SexualOrientation",
-                    "type": "Identifier",
-                    "namespace": "shr.sex"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -22666,6 +25506,7 @@
               "type": "DataElement",
               "label": "SexualOrientation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0205949",
@@ -22677,13 +25518,13 @@
               ],
               "description": "An inherent and enduring emotional, romantic or sexual attraction to other people.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "CodeableConceptObservation",
+                  "label": "Observation",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -22695,6 +25536,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/sex/vs/SexualOrientationVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -22714,28 +25556,22 @@
           "label": "shr.skin",
           "type": "Namespace",
           "description": "SHR implementation of the HL7 Pressure Ulcer Prevention Domain Analysis Model (May, 2011).",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "CausativeFactor",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The cause the irritation or inflammation.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -22751,6 +25587,7 @@
                       {
                         "type": "ValueSetConstraint",
                         "valueset": "urn:tbd:PressureUlcerCausationVS",
+                        "bindingStrength": "REQUIRED",
                         "path": ""
                       }
                     ],
@@ -22782,11 +25619,12 @@
               "type": "DataElement",
               "label": "ImmersionDepth",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Depth of penetration (sinking) into a support surface.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -22820,6 +25658,7 @@
               "type": "DataElement",
               "label": "PressureUlcer",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0011127",
@@ -22831,15 +25670,15 @@
               ],
               "description": "A single pressure ulcer, tracked over a period of time. Multiple PressureUlcerAssessments (at different times) may be associated with a single PressureUlcer.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "Problem",
+                  "label": "Condition",
                   "type": "Identifier",
-                  "namespace": "shr.problem"
+                  "namespace": "shr.condition"
                 }
               ],
               "value": {
@@ -22871,11 +25710,9 @@
                   "min": 0,
                   "constraints": [
                     {
-                      "type": "TypeConstraint",
-                      "isA": {
-                        "_namespace": "shr.skin",
-                        "_name": "PressureUlcerBodySite"
-                      },
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/skin/vs/PressureUlcerBodySiteVS",
+                      "bindingStrength": "EXTENSIBLE",
                       "path": ""
                     }
                   ],
@@ -22900,11 +25737,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
+                  "label": "shr.observation:Manifestation",
                   "identifier": {
                     "label": "Manifestation",
                     "type": "Identifier",
-                    "namespace": "shr.problem"
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -22928,83 +25765,9 @@
             },
             {
               "type": "DataElement",
-              "label": "PressureUlcerBodySite",
-              "isEntry": false,
-              "concepts": [],
-              "description": "The site of a pressure ulcer.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "BodySite",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              ],
-              "value": {
-                "min": 1,
-                "max": 1,
-                "constraints": [
-                  {
-                    "type": "ValueSetConstraint",
-                    "valueset": "http://standardhealthrecord.org/shr/skin/vs/PressureUlcerBodySiteVS",
-                    "path": ""
-                  }
-                ],
-                "type": "IdentifiableValue",
-                "label": "shr.core:CodeableConcept",
-                "identifier": {
-                  "label": "CodeableConcept",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
-              "children": [
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Laterality",
-                  "identifier": {
-                    "label": "Laterality",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:Directionality",
-                  "identifier": {
-                    "label": "Directionality",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:PortionTotality",
-                  "identifier": {
-                    "label": "PortionTotality",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
               "label": "PressureUlcerManifestation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:54574-9",
@@ -23016,15 +25779,15 @@
               ],
               "description": "Observation regarding the properties and severity of a single pressure ulcer.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
                   "label": "Manifestation",
                   "type": "Identifier",
-                  "namespace": "shr.problem"
+                  "namespace": "shr.observation"
                 }
               ],
               "children": [
@@ -23043,11 +25806,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -23055,15 +25818,28 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/observation/vs/NonLabObservationStatusVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationStatus",
+                  "label": "shr.base:Status",
                   "identifier": {
-                    "label": "ObservationStatus",
+                    "label": "Status",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
+                  }
+                },
+                {
+                  "min": 1,
+                  "max": 1,
+                  "constraints": [],
+                  "type": "IdentifiableValue",
+                  "label": "shr.core:BodySite",
+                  "identifier": {
+                    "label": "BodySite",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
                   }
                 },
                 {
@@ -23153,189 +25929,9 @@
             },
             {
               "type": "DataElement",
-              "label": "PressureUlcerNotPresent",
-              "isEntry": true,
-              "concepts": [],
-              "description": "A statement that there is no pressure ulcer at a given body site. If body site is omitted, or if the body site is a coding representing the entire body, then the inference is that no pressure ulcers is present anywhere on the body.",
-              "grammarVersion": {
-                "major": 4,
-                "minor": 1,
-                "patch": 0
-              },
-              "basedOn": [
-                {
-                  "label": "PressureUlcer",
-                  "type": "Identifier",
-                  "namespace": "shr.skin"
-                }
-              ],
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "BooleanConstraint",
-                      "value": true,
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.base:NonOccurrenceModifier",
-                  "identifier": {
-                    "label": "NonOccurrenceModifier",
-                    "type": "Identifier",
-                    "namespace": "shr.base"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:GeneralizedLikelihood",
-                  "identifier": {
-                    "label": "GeneralizedLikelihood",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:SupportingEvidenceQuality",
-                  "identifier": {
-                    "label": "SupportingEvidenceQuality",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 1,
-                  "max": 1,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:ClinicalStatus",
-                  "identifier": {
-                    "label": "ClinicalStatus",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:IncludeOnProblemList",
-                  "identifier": {
-                    "label": "IncludeOnProblemList",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Onset",
-                  "identifier": {
-                    "label": "Onset",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:WhenClinicallyRecognized",
-                  "identifier": {
-                    "label": "WhenClinicallyRecognized",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Preexisting",
-                  "identifier": {
-                    "label": "Preexisting",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Abatement",
-                  "identifier": {
-                    "label": "Abatement",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Severity",
-                  "identifier": {
-                    "label": "Severity",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Criticality",
-                  "identifier": {
-                    "label": "Criticality",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:GradeOrStage",
-                  "identifier": {
-                    "label": "GradeOrStage",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                },
-                {
-                  "min": 0,
-                  "max": 0,
-                  "constraints": [],
-                  "type": "IdentifiableValue",
-                  "label": "shr.problem:Manifestation",
-                  "identifier": {
-                    "label": "Manifestation",
-                    "type": "Identifier",
-                    "namespace": "shr.problem"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "DataElement",
               "label": "SupportSurface",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://snomed.info/sct:272243001",
@@ -23347,8 +25943,8 @@
               ],
               "description": "A specific instance of a support surface used to distribute pressure and support a patient. The value is coding of the type of support surface.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -23365,6 +25961,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -23418,11 +26015,12 @@
               "type": "DataElement",
               "label": "SupportSurfaceBodyPosition",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "What body positions the surface can be used for, specifically, sitting or lying.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23432,6 +26030,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceBodyPositionVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -23449,11 +26048,12 @@
               "type": "DataElement",
               "label": "SupportSurfaceCategory",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "The category of support surface.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23463,6 +26063,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceCategoryVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -23480,11 +26081,12 @@
               "type": "DataElement",
               "label": "SupportSurfaceComponent",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A physical material, structure, or system used alone or in combination with other components to fashion a support surface.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23494,6 +26096,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceComponentVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -23511,11 +26114,12 @@
               "type": "DataElement",
               "label": "SupportSurfaceEmployed",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A paricular instance of the use of a support surface in patient care.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -23581,11 +26185,12 @@
               "type": "DataElement",
               "label": "VisibleInternalStructure",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "An internal body structure visible from outside the body, for example, due to injury.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23595,6 +26200,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/skin/vs/VisibleInternalStructureVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -23612,11 +26218,12 @@
               "type": "DataElement",
               "label": "WoundBedAndEdge",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -23666,6 +26273,7 @@
               "type": "DataElement",
               "label": "WoundEdgeAppearance",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:723204-9",
@@ -23677,8 +26285,8 @@
               ],
               "description": "Evaluation of the state of the tissue at the edge of the wound.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23688,6 +26296,7 @@
                   {
                     "type": "ValueSetConstraint",
                     "valueset": "http://standardhealthrecord.org/shr/skin/vs/WoundEdgeAppearanceVS",
+                    "bindingStrength": "REQUIRED",
                     "path": ""
                   }
                 ],
@@ -23705,11 +26314,12 @@
               "type": "DataElement",
               "label": "WoundExudate",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "A mass of cells and fluid that has seeped out of a wound.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23759,6 +26369,7 @@
               "type": "DataElement",
               "label": "WoundSize",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C3496620",
@@ -23770,8 +26381,8 @@
               ],
               "description": "The estimated or measured dimensions of a wound.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "children": [
@@ -23853,6 +26464,7 @@
               "type": "DataElement",
               "label": "WoundTunnelling",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://ncimeta.nci.nih.gov:C0406830",
@@ -23864,8 +26476,8 @@
               ],
               "description": "A discharging blind-ended track that extends from the surface of an organ to an underlying area or abscess cavity. The track is invariably lined with granulation tissue. In chronic cases this may be augmented with epithelial tissue.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23911,11 +26523,12 @@
               "type": "DataElement",
               "label": "WoundUndermining",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [],
               "description": "Assessment of deep tissue (subcutaneous fat and muscle) damage around the wound margin. Tunneling is just under the skin surface and doesn't involve deep tissue, and sinus tracts are a narrow tract that are away from the wound margins and go downward into the wound.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -23958,23 +26571,17 @@
           "label": "shr.vital",
           "type": "Namespace",
           "description": "The SHR Vital domain contains definitions for basic physiological measurements categorized as vital signs.",
-          "grammarVersion": [
-            {
-              "major": 4,
-              "minor": 1,
-              "patch": 0
-            },
-            {
-              "major": 4,
-              "minor": 0,
-              "patch": 0
-            }
-          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
           "children": [
             {
               "type": "DataElement",
               "label": "BloodPressure",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:55284-4",
@@ -23986,8 +26593,8 @@
               ],
               "description": "The force of circulating blood on the walls of the arteries.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -23997,39 +26604,56 @@
                   "namespace": "shr.vital"
                 }
               ],
-              "value": {
-                "min": 0,
-                "max": 0,
-                "constraints": [],
-                "type": "IdentifiableValue",
-                "label": "shr.core:Quantity",
-                "identifier": {
-                  "label": "Quantity",
-                  "type": "Identifier",
-                  "namespace": "shr.core"
-                }
-              },
               "children": [
                 {
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:55284-4",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "55284-4",
-                        "url": "http://s.details.loinc.org/LOINC/55284-4.html"
-                      },
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureBodySiteVS",
+                      "bindingStrength": "REQUIRED",
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
+                  "label": "shr.core:BodySite",
                   "identifier": {
-                    "label": "TestCode",
+                    "label": "BodySite",
+                    "type": "Identifier",
+                    "namespace": "shr.core"
+                  }
+                },
+                {
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureMethodVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.lab:TestMethod",
+                  "identifier": {
+                    "label": "TestMethod",
                     "type": "Identifier",
                     "namespace": "shr.lab"
+                  }
+                },
+                {
+                  "constraints": [
+                    {
+                      "type": "ValueSetConstraint",
+                      "valueset": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureQualifierVS",
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
+                    }
+                  ],
+                  "type": "IdentifiableValue",
+                  "label": "shr.observation:ObservationQualifier",
+                  "identifier": {
+                    "label": "ObservationQualifier",
+                    "type": "Identifier",
+                    "namespace": "shr.observation"
                   }
                 },
                 {
@@ -24057,54 +26681,6 @@
                   }
                 },
                 {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureBodySiteVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.core:BodySite",
-                  "identifier": {
-                    "label": "BodySite",
-                    "type": "Identifier",
-                    "namespace": "shr.core"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureMethodVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestMethod",
-                  "identifier": {
-                    "label": "TestMethod",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
-                      "type": "ValueSetConstraint",
-                      "valueset": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureQualifierVS",
-                      "path": "shr.core.CodeableConcept"
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationQualifier",
-                  "identifier": {
-                    "label": "ObservationQualifier",
-                    "type": "Identifier",
-                    "namespace": "shr.observation"
-                  }
-                },
-                {
                   "min": 0,
                   "max": 1,
                   "constraints": [],
@@ -24122,6 +26698,7 @@
               "type": "DataElement",
               "label": "BodyHeight",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8302-2",
@@ -24133,8 +26710,8 @@
               ],
               "description": "The distance from the sole to the crown of the head.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24173,31 +26750,10 @@
                 {
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:8302-2",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "8302-2",
-                        "url": "http://s.details.loinc.org/LOINC/8302-2.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/BodyHeightQualifierVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24214,6 +26770,7 @@
               "type": "DataElement",
               "label": "BodyLength",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8306-3",
@@ -24225,8 +26782,8 @@
               ],
               "description": "The distance from the sole of the foot to the crown of the head, lying down (typically 0-2 years).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24261,35 +26818,13 @@
                   "namespace": "shr.core"
                 }
               },
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:8306-3",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "8306-3",
-                        "url": "http://s.details.loinc.org/LOINC/8306-3.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                }
-              ]
+              "children": []
             },
             {
               "type": "DataElement",
               "label": "BodyMassIndex",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:39156-5",
@@ -24301,8 +26836,8 @@
               ],
               "description": "A general indicator of the body fat an individual is carrying based upon the ratio of weight to height.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24312,29 +26847,19 @@
                   "namespace": "shr.vital"
                 }
               ],
+              "value": {
+                "min": 1,
+                "max": 1,
+                "constraints": [],
+                "type": "IdentifiableValue",
+                "label": "shr.core:Quantity",
+                "identifier": {
+                  "label": "Quantity",
+                  "type": "Identifier",
+                  "namespace": "shr.core"
+                }
+              },
               "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:39156-5",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "39156-5",
-                        "url": "http://s.details.loinc.org/LOINC/39156-5.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
                 {
                   "min": 0,
                   "max": 1,
@@ -24365,6 +26890,7 @@
               "type": "DataElement",
               "label": "BodyTemperature",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8310-5",
@@ -24376,8 +26902,8 @@
               ],
               "description": "The measure of the level of heat in a human or animal.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24416,31 +26942,10 @@
                 {
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:8310-5",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "8310-5",
-                        "url": "http://s.details.loinc.org/LOINC/8310-5.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/BodyTemperatureBodySiteVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24456,7 +26961,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/BodyTemperatureQualifierVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24473,6 +26979,7 @@
               "type": "DataElement",
               "label": "BodyWeight",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:29463-7",
@@ -24484,8 +26991,8 @@
               ],
               "description": "The mass or quantity of heaviness of an individual. Does not include estimates of fetal bodyweight.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24524,31 +27031,10 @@
                 {
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:29463-7",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "29463-7",
-                        "url": "http://s.details.loinc.org/LOINC/29463-7.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/BodyWeightQualifierVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24565,6 +27051,7 @@
               "type": "DataElement",
               "label": "DiastolicPressure",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8462-4",
@@ -24576,13 +27063,13 @@
               ],
               "description": "The blood pressure after the contraction of the heart while the chambers of the heart refill with blood, when the pressure is lowest.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "ObservationComponent",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -24628,11 +27115,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -24641,6 +27128,7 @@
               "type": "DataElement",
               "label": "HeadCircumference",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8287-5",
@@ -24652,8 +27140,8 @@
               ],
               "description": "Circumference of the head (typically 0-2 years).",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24688,35 +27176,13 @@
                   "namespace": "shr.core"
                 }
               },
-              "children": [
-                {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:8287-5",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "8287-5",
-                        "url": "http://s.details.loinc.org/LOINC/8287-5.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                }
-              ]
+              "children": []
             },
             {
               "type": "DataElement",
               "label": "HeadTiltAngle",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8360-0",
@@ -24728,8 +27194,8 @@
               ],
               "description": "The angle at which the head is tilted relative to a level position while physiologic tests are taken.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "value": {
@@ -24763,6 +27229,7 @@
               "type": "DataElement",
               "label": "HeartRate",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8867-4",
@@ -24774,8 +27241,8 @@
               ],
               "description": "The number of times the heart ventricles contract per unit of time, usually per minute.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24814,31 +27281,10 @@
                 {
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:8867-4",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "8867-4",
-                        "url": "http://s.details.loinc.org/LOINC/8867-4.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/HeartRateQualifierVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24856,7 +27302,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/HeartRateMethodVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24873,6 +27320,7 @@
               "type": "DataElement",
               "label": "OxygenSaturation",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:59408-5",
@@ -24884,8 +27332,8 @@
               ],
               "description": "Oxygen saturation in Arterial blood by Pulse oximetry.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -24922,35 +27370,14 @@
               },
               "children": [
                 {
-                  "constraints": [
-                    {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:59408-5",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "59408-5",
-                        "url": "http://s.details.loinc.org/LOINC/59408-5.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
                   "min": 0,
                   "max": 1,
                   "constraints": [
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/OxygenSaturationBodySiteVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -24967,6 +27394,7 @@
               "type": "DataElement",
               "label": "RespiratoryRate",
               "isEntry": true,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:9279-1",
@@ -24978,8 +27406,8 @@
               ],
               "description": "The rate of breathing (inhalation and exhalation) measured within in a unit time, expressed as breaths per minute.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -25018,31 +27446,10 @@
                 {
                   "constraints": [
                     {
-                      "type": "CodeConstraint",
-                      "code": {
-                        "label": "http://loinc.org:9279-1",
-                        "type": "Concept",
-                        "system": "http://loinc.org",
-                        "code": "9279-1",
-                        "url": "http://s.details.loinc.org/LOINC/9279-1.html"
-                      },
-                      "path": ""
-                    }
-                  ],
-                  "type": "IdentifiableValue",
-                  "label": "shr.lab:TestCode",
-                  "identifier": {
-                    "label": "TestCode",
-                    "type": "Identifier",
-                    "namespace": "shr.lab"
-                  }
-                },
-                {
-                  "constraints": [
-                    {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/RespiratoryRateQualifierVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -25060,7 +27467,8 @@
                     {
                       "type": "ValueSetConstraint",
                       "valueset": "http://standardhealthrecord.org/shr/vital/vs/RespiratoryRateMethodVS",
-                      "path": "shr.core.CodeableConcept"
+                      "bindingStrength": "REQUIRED",
+                      "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
@@ -25077,6 +27485,7 @@
               "type": "DataElement",
               "label": "SystolicPressure",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "http://loinc.org:8480-6",
@@ -25088,13 +27497,13 @@
               ],
               "description": "The blood pressure during the contraction of the left ventricle of the heart, when blood pressure is at its highest.",
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
                 {
-                  "label": "QuantitativeObservation",
+                  "label": "ObservationComponent",
                   "type": "Identifier",
                   "namespace": "shr.observation"
                 }
@@ -25140,11 +27549,11 @@
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCode",
+                  "label": "shr.core:SpecificType",
                   "identifier": {
-                    "label": "ObservationCode",
+                    "label": "SpecificType",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.core"
                   }
                 }
               ]
@@ -25153,6 +27562,7 @@
               "type": "DataElement",
               "label": "VitalSign",
               "isEntry": false,
+              "isAbstract": false,
               "concepts": [
                 {
                   "label": "Vital Sign (http://loinc.org:8716-3)",
@@ -25164,8 +27574,8 @@
                 }
               ],
               "grammarVersion": {
-                "major": 4,
-                "minor": 1,
+                "major": 5,
+                "minor": 0,
                 "patch": 0
               },
               "basedOn": [
@@ -25176,7 +27586,7 @@
                 }
               ],
               "value": {
-                "min": 0,
+                "min": 1,
                 "max": 1,
                 "constraints": [],
                 "type": "IdentifiableValue",
@@ -25189,26 +27599,25 @@
               },
               "children": [
                 {
-                  "min": 1,
                   "constraints": [
                     {
-                      "type": "IncludesCodeConstraint",
+                      "type": "CodeConstraint",
                       "code": {
-                        "label": "http://hl7.org/fhir/observation-category:vital-signs",
+                        "label": "null:vital-signs",
                         "type": "Concept",
-                        "system": "http://hl7.org/fhir/observation-category",
+                        "system": null,
                         "code": "vital-signs",
-                        "url": "http://hl7.org/fhir/observation-category#definition"
+                        "url": ""
                       },
                       "path": ""
                     }
                   ],
                   "type": "IdentifiableValue",
-                  "label": "shr.observation:ObservationCategory",
+                  "label": "shr.base:Category",
                   "identifier": {
-                    "label": "ObservationCategory",
+                    "label": "Category",
                     "type": "Identifier",
-                    "namespace": "shr.observation"
+                    "namespace": "shr.base"
                   }
                 },
                 {
@@ -25235,7 +27644,7 @@
           "url": "http://standardhealthrecord.org/shr/actor/vs/HealthcareRoleVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25414,7 +27823,7 @@
           "url": "http://standardhealthrecord.org/shr/actor/vs/AgeGroupVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25516,7 +27925,7 @@
           "url": "http://standardhealthrecord.org/shr/actor/vs/LanguageQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25618,8 +28027,8 @@
           "url": "http://standardhealthrecord.org/shr/adverse/vs/MedDRAVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -25631,13 +28040,82 @@
           ]
         },
         {
+          "label": "AdverseEventGradeVS",
+          "namespace": "shr.adverse",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/adverse/vs/AdverseEventGradeVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Mild Adverse Event. Transient or mild discomfort, no limitaion in activity; no medical intervention or therapy required",
+              "code": {
+                "label": "Mild Adverse Event. Transient or mild discomfort, no limitaion in activity; no medical intervention or therapy required",
+                "type": "code",
+                "code": "C1513302",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1513302;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Moderate Adverse Event. Daily activity is affected moderately; some assistance might be needed; no or minimal medical intervention/therapy required.",
+              "code": {
+                "label": "Moderate Adverse Event. Daily activity is affected moderately; some assistance might be needed; no or minimal medical intervention/therapy required.",
+                "type": "code",
+                "code": "C1513374",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1513374;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Severe Adverse Event. Daily activity is markedly reduced; some assistance usually required; medical intervention/therapy required, hospitalization or hospice care possible.",
+              "code": {
+                "label": "Severe Adverse Event. Daily activity is markedly reduced; some assistance usually required; medical intervention/therapy required, hospitalization or hospice care possible.",
+                "type": "code",
+                "code": "C1519275",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1519275;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Potentially Life-Threatening Adverse Event. Extreme limitation to daily activity, significant assistance required; significant medical intervention/therapy, hospitalization or hospice care very likely.",
+              "code": {
+                "label": "Potentially Life-Threatening Adverse Event. Extreme limitation to daily activity, significant assistance required; significant medical intervention/therapy, hospitalization or hospice care very likely.",
+                "type": "code",
+                "code": "C1517874",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1517874;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Fatal Adverse Event. Adverse event associated with death",
+              "code": {
+                "label": "Fatal Adverse Event. Adverse event associated with death",
+                "type": "code",
+                "code": "C1559081",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1559081;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
           "label": "AllergenIrritantVS",
           "namespace": "shr.allergy",
           "type": "ValueSet",
           "url": "http://standardhealthrecord.org/shr/allergy/vs/AllergenIrritantVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25662,7 +28140,7 @@
           "url": "http://standardhealthrecord.org/shr/allergy/vs/FoodSubstanceVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25688,7 +28166,7 @@
           "url": "http://standardhealthrecord.org/shr/allergy/vs/DrugIngredientVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           }
@@ -25701,7 +28179,7 @@
           "url": "http://standardhealthrecord.org/shr/allergy/vs/AllergyVerificationStatusVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25731,6 +28209,156 @@
           ]
         },
         {
+          "label": "AssessmentTypeVS",
+          "namespace": "shr.assessment",
+          "description": "A code describing the type of assessment activity, e.g. diagnosis, prognosis, disease progression, healing, toxicity, treatment efficacy.",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/assessment/vs/AssessmentTypeVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Prognosis - a prediction of the probable outcome of a disease based on a individual's condition and the usual course of the disease as seen in similar situations",
+              "code": {
+                "label": "Prognosis - a prediction of the probable outcome of a disease based on a individual's condition and the usual course of the disease as seen in similar situations",
+                "type": "code",
+                "code": "C0033325",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0033325;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Diagnosis  - The determination of the nature and/or extent of a disease or condition, or the distinguishing of one disease or condition from another. The assessment may be made through physical examination, laboratory tests, or the likes. Computerized programs may be used to enhance the decision-making process.",
+              "code": {
+                "label": "Diagnosis  - The determination of the nature and/or extent of a disease or condition, or the distinguishing of one disease or condition from another. The assessment may be made through physical examination, laboratory tests, or the likes. Computerized programs may be used to enhance the decision-making process.",
+                "type": "code",
+                "code": "C0011900",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0011900;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Assessment of disease progression",
+              "code": {
+                "label": "Assessment of disease progression",
+                "type": "code",
+                "code": "C0421176",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0421176;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Assessment of recovery process, from surgery, therapy, or similar treatment.",
+              "code": {
+                "label": "Assessment of recovery process, from surgery, therapy, or similar treatment.",
+                "type": "code",
+                "code": "C2004454",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C2004454;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Assessment of adverse effects of a treatment.",
+              "code": {
+                "label": "Assessment of adverse effects of a treatment.",
+                "type": "code",
+                "code": "C0879626",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0879626;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Assessment of the effectiveness of a treatment.",
+              "code": {
+                "label": "Assessment of the effectiveness of a treatment.",
+                "type": "code",
+                "code": "C0087113",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0087113;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Assessment of risk for a disease.",
+              "code": {
+                "label": "Assessment of risk for a disease.",
+                "type": "code",
+                "code": "C4040556",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C4040556;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "EvidenceQualityVS",
+          "namespace": "shr.assessment",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/assessment/vs/EvidenceQualityVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty.",
+              "code": {
+                "label": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty.",
+                "type": "code",
+                "code": "compelling_evidence",
+                "system": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+                "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence.",
+              "code": {
+                "label": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence.",
+                "type": "code",
+                "code": "suggestive_evidence",
+                "system": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+                "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments.",
+              "code": {
+                "label": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments.",
+                "type": "code",
+                "code": "weak_evidence",
+                "system": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+                "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "No evidence",
+              "code": {
+                "label": "No evidence",
+                "type": "code",
+                "code": "C0332125",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0332125;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
           "label": "MissingValueReasonVS",
           "namespace": "shr.base",
           "description": "Reasons that a value associated with a test or other observation is missing.",
@@ -25738,7 +28366,7 @@
           "url": "http://standardhealthrecord.org/shr/base/vs/MissingValueReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25840,7 +28468,7 @@
           "url": "http://standardhealthrecord.org/shr/base/vs/GenericAnswersVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25887,7 +28515,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/ReligiousPracticeStatusVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25935,7 +28563,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/ReligiousRestrictionVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -25982,7 +28610,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/SubstanceOfAbuseVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26007,7 +28635,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/SubstanceAbuseTreatmentTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26142,7 +28770,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/AlcoholUseScreeningToolVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26189,7 +28817,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/SpecialDietFollowedVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26269,7 +28897,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/DietNutritionConcernVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26481,7 +29109,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/SleepQualityReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26616,7 +29244,7 @@
           "url": "http://standardhealthrecord.org/shr/behavior/vs/PhysicalActivityLimitationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -26756,14 +29384,138 @@
           ]
         },
         {
+          "label": "DSMVS",
+          "namespace": "shr.condition",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/condition/vs/DSMVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "http://www.dsm5.org/",
+              "system": "http://www.dsm5.org/",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            }
+          ]
+        },
+        {
+          "label": "ConditionVS",
+          "namespace": "shr.condition",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/condition/vs/ConditionVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "disease",
+              "code": {
+                "label": "disease",
+                "type": "code",
+                "code": "64572001",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=64572001"
+              },
+              "type": "ValueSetIncludesDescendentsRule"
+            }
+          ]
+        },
+        {
+          "label": "ConditionCategoryVS",
+          "namespace": "shr.condition",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/condition/vs/ConditionCategoryVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury.",
+              "code": {
+                "label": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury.",
+                "type": "code",
+                "code": "disease",
+                "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+                "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "A disability experienced by the subject.",
+              "code": {
+                "label": "A disability experienced by the subject.",
+                "type": "code",
+                "code": "functional_impairment",
+                "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+                "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "An abnormality of physiologic structure.",
+              "code": {
+                "label": "An abnormality of physiologic structure.",
+                "type": "code",
+                "code": "structural_abnormality",
+                "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+                "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder.",
+              "code": {
+                "label": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder.",
+                "type": "code",
+                "code": "concern",
+                "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+                "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "A sign or manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears.",
+              "code": {
+                "label": "A sign or manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears.",
+                "type": "code",
+                "code": "symptom",
+                "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+                "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "An adverse reaction to an intervention.",
+              "code": {
+                "label": "An adverse reaction to an intervention.",
+                "type": "code",
+                "code": "adverse_reaction",
+                "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+                "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
           "label": "CodingQualifierVS",
           "namespace": "shr.core",
           "type": "ValueSet",
           "url": "http://standardhealthrecord.org/shr/core/vs/CodingQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -26853,8 +29605,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/ClockDirectionVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -26999,8 +29751,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/UpperBoundTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27035,8 +29787,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/LowerBoundTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27072,8 +29824,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/StatisticTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27174,8 +29926,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/TimeUnitOfMeasureVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27276,8 +30028,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/QualitativeDateTimeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27510,8 +30262,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeDurationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27623,8 +30375,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/SemiquantitativeFrequencyVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27780,8 +30532,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/QualitativeFrequencyVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27849,8 +30601,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/ThreeValueLogicVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27896,8 +30648,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/QualitativeValueScaleVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -27924,9 +30676,9 @@
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Moderate",
+              "label": "Moderate/Intermediate or Borderline",
               "code": {
-                "label": "Moderate",
+                "label": "Moderate/Intermediate or Borderline",
                 "type": "code",
                 "code": "moderate",
                 "system": "http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS",
@@ -27966,8 +30718,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/QualitativeLikelihoodVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28046,8 +30798,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/ThreePriorityVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28094,8 +30846,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/SettingVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28491,8 +31243,8 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28622,9 +31374,43 @@
         {
           "label": "BodySiteVS",
           "namespace": "shr.core",
-          "description": "Location on or in the body.",
+          "description": "Codes that describe normal and pathologic anatomic systems, regions, cavities, and spaces.",
           "type": "ValueSet",
           "url": "http://standardhealthrecord.org/shr/core/vs/BodySiteVS",
+          "concepts": [
+            {
+              "label": "http://ncimeta.nci.nih.gov:C1545955",
+              "type": "Concept",
+              "system": "http://ncimeta.nci.nih.gov",
+              "code": "C1545955",
+              "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1545955;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+            }
+          ],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Body Structure",
+              "code": {
+                "label": "Body Structure",
+                "type": "code",
+                "code": "123037004",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=123037004"
+              },
+              "type": "ValueSetIncludesDescendentsRule"
+            }
+          ]
+        },
+        {
+          "label": "BodyStructureVS",
+          "namespace": "shr.core",
+          "description": "Codes that describe normal and pathologic anatomic systems, regions, cavities, and spaces.",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/core/vs/BodyStructureVS",
           "concepts": [
             {
               "label": "http://ncimeta.nci.nih.gov:C1268086",
@@ -28635,43 +31421,21 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "Body Part, Organ, or Organ Component",
+              "label": "Body Structure",
               "code": {
-                "label": "Body Part, Organ, or Organ Component",
+                "label": "Body Structure",
                 "type": "code",
-                "code": "T023",
-                "system": "http://ncimeta.nci.nih.gov",
-                "url": "https://uts.nlm.nih.gov/metathesaurus.html#T023;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+                "code": "123037004",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=123037004"
               },
-              "type": "ValueSetIncludesFromCodeRule"
-            },
-            {
-              "label": "Body Location or Region",
-              "code": {
-                "label": "Body Location or Region",
-                "type": "code",
-                "code": "T029",
-                "system": "http://ncimeta.nci.nih.gov",
-                "url": "https://uts.nlm.nih.gov/metathesaurus.html#T029;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-              },
-              "type": "ValueSetIncludesFromCodeRule"
-            },
-            {
-              "label": "Body Space or Junction",
-              "code": {
-                "label": "Body Space or Junction",
-                "type": "code",
-                "code": "T030",
-                "system": "http://ncimeta.nci.nih.gov",
-                "url": "https://uts.nlm.nih.gov/metathesaurus.html#T030;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
-              },
-              "type": "ValueSetIncludesFromCodeRule"
+              "type": "ValueSetIncludesDescendentsRule"
             }
           ]
         },
@@ -28692,8 +31456,8 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28726,8 +31490,8 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28760,8 +31524,8 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28786,8 +31550,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/PerformanceGradingScaleVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28849,39 +31613,14 @@
           ]
         },
         {
-          "label": "ManifestationVS",
-          "namespace": "shr.core",
-          "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/core/vs/ManifestationVS",
-          "concepts": [],
-          "grammarVersion": {
-            "major": 4,
-            "minor": 1,
-            "patch": 0
-          },
-          "children": [
-            {
-              "label": "Finding reported by subject or history provider",
-              "code": {
-                "label": "Finding reported by subject or history provider",
-                "type": "code",
-                "code": "418799008",
-                "system": "http://snomed.info/sct",
-                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=418799008"
-              },
-              "type": "ValueSetIncludesDescendentsRule"
-            }
-          ]
-        },
-        {
           "label": "DiseaseFindingVS",
           "namespace": "shr.core",
           "type": "ValueSet",
           "url": "http://standardhealthrecord.org/shr/core/vs/DiseaseFindingVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28905,8 +31644,8 @@
           "url": "http://standardhealthrecord.org/shr/core/vs/ClinicalFindingAbsentVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -28924,6 +31663,35 @@
           ]
         },
         {
+          "label": "SpecificTypeVS",
+          "namespace": "shr.core",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/core/vs/SpecificTypeVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "http://loinc.org",
+              "system": "http://loinc.org",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            },
+            {
+              "label": "http://ncimeta.nci.nih.gov",
+              "system": "http://ncimeta.nci.nih.gov",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            },
+            {
+              "label": "http://snomed.info/sct",
+              "system": "http://snomed.info/sct",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            }
+          ]
+        },
+        {
           "label": "AddressUseVS",
           "namespace": "shr.demographics",
           "description": "How an address is used by the subject, for example, as a dwelling or as a mailing address.",
@@ -28931,7 +31699,7 @@
           "url": "http://standardhealthrecord.org/shr/demographics/vs/AddressUseVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29011,7 +31779,7 @@
           "url": "http://standardhealthrecord.org/shr/demographics/vs/TelephoneTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29047,7 +31815,7 @@
           "url": "http://standardhealthrecord.org/shr/demographics/vs/TelecomQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29193,7 +31961,7 @@
           "url": "http://standardhealthrecord.org/shr/demographics/vs/InsuranceProviderTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29284,7 +32052,7 @@
           "url": "http://standardhealthrecord.org/shr/device/vs/RespiratoryRateSettingVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29364,7 +32132,7 @@
           "url": "http://standardhealthrecord.org/shr/device/vs/RespiratoryAssistDeviceVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29433,7 +32201,7 @@
           "url": "http://standardhealthrecord.org/shr/encounter/vs/EpisodeOfCareCompletionVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29557,7 +32325,7 @@
           "url": "http://standardhealthrecord.org/shr/encounter/vs/EncounterUrgencyVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29593,7 +32361,7 @@
           "url": "http://standardhealthrecord.org/shr/encounter/vs/EncounterTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29673,7 +32441,7 @@
           "url": "http://standardhealthrecord.org/shr/encounter/vs/ReferralSourceTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29786,7 +32554,7 @@
           "url": "http://standardhealthrecord.org/shr/encounter/vs/TreatmentCooperationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29844,7 +32612,7 @@
           "url": "http://standardhealthrecord.org/shr/encounter/vs/ReasonEncounterDidNotHappenVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29902,7 +32670,7 @@
           "url": "http://standardhealthrecord.org/shr/environment/vs/ResourceStabilityVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -29960,7 +32728,7 @@
           "url": "http://standardhealthrecord.org/shr/environment/vs/IncomeSourceVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -30128,7 +32896,7 @@
           "url": "http://standardhealthrecord.org/shr/environment/vs/NonCashBenefitVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -30252,7 +33020,7 @@
           "url": "http://standardhealthrecord.org/shr/environment/vs/AnimalExposureVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -30365,7 +33133,7 @@
           "url": "http://standardhealthrecord.org/shr/environment/vs/CoinhabitantVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -30456,7 +33224,7 @@
           "url": "http://standardhealthrecord.org/shr/environment/vs/HomeEnvironmentRiskVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -30856,7 +33624,7 @@
           "url": "http://standardhealthrecord.org/shr/immunization/vs/ImmunizationNotGivenReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -30908,71 +33676,13 @@
           ]
         },
         {
-          "label": "RequestStatusVS",
-          "namespace": "shr.lab",
-          "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/lab/vs/RequestStatusVS",
-          "concepts": [],
-          "grammarVersion": {
-            "major": 4,
-            "minor": 0,
-            "patch": 0
-          },
-          "children": [
-            {
-              "label": "The request is complete and is ready for fulfillment.",
-              "code": {
-                "label": "The request is complete and is ready for fulfillment.",
-                "type": "code",
-                "code": "active",
-                "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-                "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-              },
-              "type": "ValueSetIncludesCodeRule"
-            },
-            {
-              "label": "The request is being carried out.",
-              "code": {
-                "label": "The request is being carried out.",
-                "type": "code",
-                "code": "in_progress",
-                "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-                "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-              },
-              "type": "ValueSetIncludesCodeRule"
-            },
-            {
-              "label": "The request has been held by originating system/user request.",
-              "code": {
-                "label": "The request has been held by originating system/user request.",
-                "type": "code",
-                "code": "suspended",
-                "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-                "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-              },
-              "type": "ValueSetIncludesCodeRule"
-            },
-            {
-              "label": "The diagnostic testing has been completed, the report(s) released, and no further work is planned.",
-              "code": {
-                "label": "The diagnostic testing has been completed, the report(s) released, and no further work is planned.",
-                "type": "code",
-                "code": "completed",
-                "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-                "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-              },
-              "type": "ValueSetIncludesCodeRule"
-            }
-          ]
-        },
-        {
           "label": "TestInterpretationVS",
           "namespace": "shr.lab",
           "type": "ValueSet",
           "url": "http://standardhealthrecord.org/shr/lab/vs/TestInterpretationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -31104,7 +33814,7 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -31184,7 +33894,7 @@
           "url": "http://standardhealthrecord.org/shr/lab/vs/PositiveNegativeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -31197,6 +33907,17 @@
                 "code": "C1446409",
                 "system": "http://ncimeta.nci.nih.gov",
                 "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1446409;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Borderline/Close",
+              "code": {
+                "label": "Borderline/Close",
+                "type": "code",
+                "code": "C0205189",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0205189;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
@@ -31220,7 +33941,7 @@
           "url": "http://standardhealthrecord.org/shr/lab/vs/HIVScreeningTestCodeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           }
@@ -31232,7 +33953,7 @@
           "url": "http://standardhealthrecord.org/shr/lab/vs/HIVScreeningTestResultVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -31290,7 +34011,7 @@
           "url": "http://standardhealthrecord.org/shr/lab/vs/HIVSupplementalTestCodeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           }
@@ -31302,7 +34023,7 @@
           "url": "http://standardhealthrecord.org/shr/lab/vs/HIVSupplementalTestResultVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -31437,7 +34158,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/EducationalAttainmentVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -31561,7 +34282,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/TeratogenVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32191,7 +34912,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/CongenitalAbnormalitiesVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32216,7 +34937,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/EmploymentStatusVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32373,7 +35094,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/MilitaryStatusVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32420,7 +35141,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/USMilitaryBranchVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32511,7 +35232,7 @@
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/MilitaryServiceDischargeStatusVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32576,12 +35297,12 @@
         {
           "label": "MilitaryServiceEraVS",
           "namespace": "shr.lifehistory",
-          "description": "Values were taken from Final HMIS Data Standards March 2010 (Homeless Management Information System), field 4.15E Veteran’s Information. See: https://www.onecpd.info/resources/documents/FinalHMISDataStandards_March2010.pdf.",
+          "description": "Values were taken from Final HMIS Data Standards March 2010 (Homeless Management Information System), field 5.05E Veteran’s Information. See: https://www.onecpd.info/resources/documents/FinalHMISDataStandards_March2010.pdf.",
           "type": "ValueSet",
           "url": "http://standardhealthrecord.org/shr/lifehistory/vs/MilitaryServiceEraVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -32683,8 +35404,8 @@
           "url": "http://standardhealthrecord.org/shr/medication/vs/MedicationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -32702,8 +35423,8 @@
           "url": "http://standardhealthrecord.org/shr/medication/vs/ReasonMedicationNotUsedVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -32826,8 +35547,8 @@
           "url": "http://standardhealthrecord.org/shr/medication/vs/MedicationNonAdherenceReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -32961,8 +35682,8 @@
           "url": "http://standardhealthrecord.org/shr/medication/vs/MedicationChangeTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -33030,8 +35751,8 @@
           "url": "http://standardhealthrecord.org/shr/medication/vs/MedicationChangeReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -33104,6 +35825,32 @@
           ]
         },
         {
+          "label": "ObservationCategoryVS",
+          "namespace": "shr.observation",
+          "description": "Class of observation made",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/observation/vs/ObservationCategoryVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Observation of a sign of symptom of an underlying condition.",
+              "code": {
+                "label": "Observation of a sign of symptom of an underlying condition.",
+                "type": "code",
+                "code": "symptom",
+                "system": "http://hl7.org/fhir/ValueSet/observation-category",
+                "url": "http://hl7.org/fhir/ValueSet/observation-category#definition"
+              },
+              "type": "ValueSetIncludesFromCodeRule"
+            }
+          ]
+        },
+        {
           "label": "NonLabObservationStatusVS",
           "namespace": "shr.observation",
           "description": "Whether the observation is complete and definite. The set of values is a subset of status values associated with lab tests.",
@@ -33111,7 +35858,7 @@
           "url": "http://standardhealthrecord.org/shr/observation/vs/NonLabObservationStatusVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -33159,7 +35906,7 @@
           "url": "http://standardhealthrecord.org/shr/observation/vs/ExposureReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -33251,7 +35998,7 @@
           "url": "http://standardhealthrecord.org/shr/observation/vs/ObservationNotMadeReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -33314,25 +36061,130 @@
           ]
         },
         {
-          "label": "MetastaticBreastCancerDiagnosisVS",
-          "namespace": "shr.oncology",
+          "label": "ManifestationVS",
+          "namespace": "shr.observation",
+          "description": "An observable sign or symptom of an underlying physical or psychological cause.",
           "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/oncology/vs/MetastaticBreastCancerDiagnosisVS",
+          "url": "http://standardhealthrecord.org/shr/observation/vs/ManifestationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "254837009",
+              "label": "Condition reported by subject or history provider",
               "code": {
-                "label": "254837009",
+                "label": "Condition reported by subject or history provider",
                 "type": "code",
-                "code": "254837009",
+                "code": "418799008",
                 "system": "http://snomed.info/sct",
-                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=254837009"
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=418799008"
+              },
+              "type": "ValueSetIncludesDescendentsRule"
+            }
+          ]
+        },
+        {
+          "label": "ObservationResultVS",
+          "namespace": "shr.observation",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/observation/vs/ObservationResultVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "http://loinc.org",
+              "system": "http://loinc.org",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            },
+            {
+              "label": "http://ncimeta.nci.nih.gov",
+              "system": "http://ncimeta.nci.nih.gov",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            },
+            {
+              "label": "http://snomed.info/sct",
+              "system": "http://snomed.info/sct",
+              "type": "ValueSetIncludesFromCodeSystemRule"
+            }
+          ]
+        },
+        {
+          "label": "NeoplasmObservationVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/NeoplasmObservationVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Neoplasm (morphologic abnormality)",
+              "code": {
+                "label": "Neoplasm (morphologic abnormality)",
+                "type": "code",
+                "code": "108369006",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=108369006"
+              },
+              "type": "ValueSetIncludesDescendentsRule"
+            }
+          ]
+        },
+        {
+          "label": "NeoplasmObservationMethodVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/NeoplasmObservationMethodVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Evaluation Procedure",
+              "code": {
+                "label": "Evaluation Procedure",
+                "type": "code",
+                "code": "386053000",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=386053000"
+              },
+              "type": "ValueSetIncludesDescendentsRule"
+            }
+          ]
+        },
+        {
+          "label": "BreastCancerTypeVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/BreastCancerTypeVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Neoplasm of the breast (disorder)",
+              "code": {
+                "label": "Neoplasm of the breast (disorder)",
+                "type": "code",
+                "code": "126926005",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=126926005"
               },
               "type": "ValueSetIncludesDescendentsRule"
             }
@@ -33345,15 +36197,15 @@
           "url": "http://standardhealthrecord.org/shr/oncology/vs/ReceptorVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "116647005",
+              "label": "Receptor (substance)",
               "code": {
-                "label": "116647005",
+                "label": "Receptor (substance)",
                 "type": "code",
                 "code": "116647005",
                 "system": "http://snomed.info/sct",
@@ -33364,215 +36216,614 @@
           ]
         },
         {
-          "label": "DSMVS",
-          "namespace": "shr.problem",
+          "label": "NottinghamCombinedGradeVS",
+          "namespace": "shr.oncology",
           "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/problem/vs/DSMVS",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/NottinghamCombinedGradeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "http://www.dsm5.org/",
-              "system": "http://www.dsm5.org/",
+              "label": "Low grade or well differentiated",
+              "code": {
+                "label": "Low grade or well differentiated",
+                "type": "code",
+                "code": "369790002",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=369790002"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Intermediate/moderate grade or moderately differentiated",
+              "code": {
+                "label": "Intermediate/moderate grade or moderately differentiated",
+                "type": "code",
+                "code": "369791003",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=369791003"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "High grade or pooly differentiated",
+              "code": {
+                "label": "High grade or pooly differentiated",
+                "type": "code",
+                "code": "369792005",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=369792005"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "LymphSystemSubdivisionVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/LymphSystemSubdivisionVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Lymphoid system subdivision (body structure)",
+              "code": {
+                "label": "Lymphoid system subdivision (body structure)",
+                "type": "code",
+                "code": "123849002",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=123849002"
+              },
+              "type": "ValueSetIncludesDescendentsRule"
+            }
+          ]
+        },
+        {
+          "label": "HER2MethodVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/HER2MethodVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Tissue by Fluorescent in situ hybridization (FISH)",
+              "code": {
+                "label": "Tissue by Fluorescent in situ hybridization (FISH)",
+                "type": "code",
+                "code": "74885-5",
+                "system": "http://loinc.org",
+                "url": "http://s.details.loinc.org/LOINC/74885-5.html"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "SPot-Light HER2 CISH test",
+              "code": {
+                "label": "SPot-Light HER2 CISH test",
+                "type": "code",
+                "code": "spot-light",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "ImmunoHistoChemistry test",
+              "code": {
+                "label": "ImmunoHistoChemistry test",
+                "type": "code",
+                "code": "ihc",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Inform HER2 Dual ISH test (In SituHybridization)",
+              "code": {
+                "label": "Inform HER2 Dual ISH test (In SituHybridization)",
+                "type": "code",
+                "code": "inform",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "DegreeOfLymphaticInvolvementVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/DegreeOfLymphaticInvolvementVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Only a few cancer cells are in the node.",
+              "code": {
+                "label": "Only a few cancer cells are in the node.",
+                "type": "code",
+                "code": "microscopic",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "The cancer can be seen or felt without aid of microscopy.",
+              "code": {
+                "label": "The cancer can be seen or felt without aid of microscopy.",
+                "type": "code",
+                "code": "gross",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Cancer has pread outside the wall of the node.",
+              "code": {
+                "label": "Cancer has pread outside the wall of the node.",
+                "type": "code",
+                "code": "extracapsular",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "GeneIdentifierVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/GeneIdentifierVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "http://www.genenames.org",
+              "system": "http://www.genenames.org",
               "type": "ValueSetIncludesFromCodeSystemRule"
             }
           ]
         },
         {
-          "label": "ProblemCategoryVS",
-          "namespace": "shr.problem",
+          "label": "SubjectiveProgressionVS",
+          "namespace": "shr.oncology",
           "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/problem/vs/ProblemCategoryVS",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/SubjectiveProgressionVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury.",
+              "label": "Complete response or remission; no measurable or observable evidence of cancer.",
               "code": {
-                "label": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury.",
+                "label": "Complete response or remission; no measurable or observable evidence of cancer.",
                 "type": "code",
-                "code": "disease",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+                "code": "C0677874",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0677874;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "A disability experienced by the subject.",
+              "label": "Complete resection/excision of cancerous tumor",
               "code": {
-                "label": "A disability experienced by the subject.",
+                "label": "Complete resection/excision of cancerous tumor",
                 "type": "code",
-                "code": "functional_impairment",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+                "code": "C0015250",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0015250;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "An abnormality of physiologic structure.",
+              "label": "Improving, responding to treatment",
               "code": {
-                "label": "An abnormality of physiologic structure.",
+                "label": "Improving, responding to treatment",
                 "type": "code",
-                "code": "structural_abnormality",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+                "code": "C1272745",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1272745;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder.",
+              "label": "Stable, neither improving nor worsening",
               "code": {
-                "label": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder.",
+                "label": "Stable, neither improving nor worsening",
                 "type": "code",
-                "code": "concern",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+                "code": "C0205360",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0205360;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "A manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears.",
+              "label": "Worsening, disease progressing",
               "code": {
-                "label": "A manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears.",
+                "label": "Worsening, disease progressing",
                 "type": "code",
-                "code": "symptom",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+                "code": "C1546960",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1546960;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "An adverse reaction to an intervention.",
+              "label": "Insufficient evidence",
               "code": {
-                "label": "An adverse reaction to an intervention.",
+                "label": "Insufficient evidence",
                 "type": "code",
-                "code": "adverse_reaction",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+                "code": "C3858734",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C3858734;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             }
           ]
         },
         {
-          "label": "EvidenceQualityVS",
-          "namespace": "shr.problem",
+          "label": "ProgressionEvidenceTypeVS",
+          "namespace": "shr.oncology",
           "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/problem/vs/EvidenceQualityVS",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/ProgressionEvidenceTypeVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty.",
+              "label": "Progression determined based on imaging",
               "code": {
-                "label": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty.",
+                "label": "Progression determined based on imaging",
                 "type": "code",
-                "code": "compelling_evidence",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS"
+                "code": "C0011923",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0011923;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence.",
+              "label": "Progression determined based on pathology",
               "code": {
-                "label": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence.",
+                "label": "Progression determined based on pathology",
                 "type": "code",
-                "code": "suggestive_evidence",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS"
+                "code": "C0030664",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0030664;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments.",
+              "label": "Progression determined based on physical signs or symptoms",
               "code": {
-                "label": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments.",
+                "label": "Progression determined based on physical signs or symptoms",
                 "type": "code",
-                "code": "weak_evidence",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS"
+                "code": "C1457887",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1457887;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Progression determined based on physical examination",
+              "code": {
+                "label": "Progression determined based on physical examination",
+                "type": "code",
+                "code": "C0031809",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0031809;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Progression determined based on biomarkers",
+              "code": {
+                "label": "Progression determined based on biomarkers",
+                "type": "code",
+                "code": "C0005516",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C0005516;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             }
           ]
         },
         {
-          "label": "GradeOrStageVS",
-          "namespace": "shr.problem",
+          "label": "TumorMarginDescriptionVS",
+          "namespace": "shr.oncology",
           "type": "ValueSet",
-          "url": "http://standardhealthrecord.org/shr/problem/vs/GradeOrStageVS",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/TumorMarginDescriptionVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "Mild",
+              "label": "Lesion with circumscribed margin",
               "code": {
-                "label": "Mild",
+                "label": "Lesion with circumscribed margin",
                 "type": "code",
-                "code": "grade_1",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+                "code": "129738007",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=129738007"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Moderate",
+              "label": "Lesion with indistinct margin",
               "code": {
-                "label": "Moderate",
+                "label": "Lesion with indistinct margin",
                 "type": "code",
-                "code": "grade_2",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+                "code": "129741003",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=129741003"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Severe",
+              "label": "Lesion with microlobulated margin",
               "code": {
-                "label": "Severe",
+                "label": "Lesion with microlobulated margin",
                 "type": "code",
-                "code": "grade_3",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+                "code": "129739004",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=129739004"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Life-threatening or disabling",
+              "label": "Lesion with obscured margin",
               "code": {
-                "label": "Life-threatening or disabling",
+                "label": "Lesion with obscured margin",
                 "type": "code",
-                "code": "grade_4",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+                "code": "129740002",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=129740002"
               },
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Death",
+              "label": "Lesion with spiculated margin",
               "code": {
-                "label": "Death",
+                "label": "Lesion with spiculated margin",
                 "type": "code",
-                "code": "grade_5",
-                "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-                "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+                "code": "129742005",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=129742005"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "StagingTimeVS",
+          "namespace": "shr.oncology",
+          "description": "When staging was done, relative to treatment events.",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/StagingTimeVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "On initial diagnosis",
+              "code": {
+                "label": "On initial diagnosis",
+                "type": "code",
+                "code": "clinical",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Post-operative, after resection surgery",
+              "code": {
+                "label": "Post-operative, after resection surgery",
+                "type": "code",
+                "code": "pathologic",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "When patient is enrolled in a clinical trial",
+              "code": {
+                "label": "When patient is enrolled in a clinical trial",
+                "type": "code",
+                "code": "enrollment",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Upon recurrence of disease",
+              "code": {
+                "label": "Upon recurrence of disease",
+                "type": "code",
+                "code": "recurrence",
+                "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+                "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "TubuleFormationScoreVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/TubuleFormationScoreVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Breast tubule formation: Majority of tumor >75% (score = 1)",
+              "code": {
+                "label": "Breast tubule formation: Majority of tumor >75% (score = 1)",
+                "type": "code",
+                "code": "369778004",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=369778004"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Breast tubule formation: Moderate 10% to 75% (score = 2)",
+              "code": {
+                "label": "Breast tubule formation: Moderate 10% to 75% (score = 2)",
+                "type": "code",
+                "code": "369779007",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=369779007"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Breast tubule formation: Minimal <10% (score = 3)",
+              "code": {
+                "label": "Breast tubule formation: Minimal <10% (score = 3)",
+                "type": "code",
+                "code": "369780005",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=369780005"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "NuclearPleomorphismScoreVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/NuclearPleomorphismScoreVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Nuclear pleomorphism: small regular nuclei (score=1)",
+              "code": {
+                "label": "Nuclear pleomorphism: small regular nuclei (score=1)",
+                "type": "code",
+                "code": "384735004",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=384735004"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Nuclear pleomorphism: moderate increase in size, etc (score = 2)",
+              "code": {
+                "label": "Nuclear pleomorphism: moderate increase in size, etc (score = 2)",
+                "type": "code",
+                "code": "384737007",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=384737007"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Nuclear pleomorphism: marked variation in size, nucleoli, chromatin clumping, etc (score = 3)",
+              "code": {
+                "label": "Nuclear pleomorphism: marked variation in size, nucleoli, chromatin clumping, etc (score = 3)",
+                "type": "code",
+                "code": "384738002",
+                "system": "http://snomed.info/sct",
+                "url": "https://uts.nlm.nih.gov/snomedctBrowser.html?conceptId=384738002"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            }
+          ]
+        },
+        {
+          "label": "ToxicReactionVS",
+          "namespace": "shr.oncology",
+          "type": "ValueSet",
+          "url": "http://standardhealthrecord.org/shr/oncology/vs/ToxicReactionVS",
+          "concepts": [],
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Severe Adverse Event. Daily activity is markedly reduced; some assistance usually required; medical intervention/therapy required, hospitalization or hospice care possible.",
+              "code": {
+                "label": "Severe Adverse Event. Daily activity is markedly reduced; some assistance usually required; medical intervention/therapy required, hospitalization or hospice care possible.",
+                "type": "code",
+                "code": "C1519275",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1519275;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Potentially Life-Threatening Adverse Event. Extreme limitation to daily activity, significant assistance required; significant medical intervention/therapy, hospitalization or hospice care very likely.",
+              "code": {
+                "label": "Potentially Life-Threatening Adverse Event. Extreme limitation to daily activity, significant assistance required; significant medical intervention/therapy, hospitalization or hospice care very likely.",
+                "type": "code",
+                "code": "C1517874",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1517874;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
+              },
+              "type": "ValueSetIncludesCodeRule"
+            },
+            {
+              "label": "Fatal Adverse Event. Adverse event associated with death",
+              "code": {
+                "label": "Fatal Adverse Event. Adverse event associated with death",
+                "type": "code",
+                "code": "C1559081",
+                "system": "http://ncimeta.nci.nih.gov",
+                "url": "https://uts.nlm.nih.gov/metathesaurus.html#C1559081;0;1;CUI;2016AB;EXACT_MATCH;CUI;*;"
               },
               "type": "ValueSetIncludesCodeRule"
             }
@@ -33585,7 +36836,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/GenderIdentityVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -33676,7 +36927,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/SexualOrientationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -33701,7 +36952,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/CommonPregnancyComplicationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -33869,7 +37120,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34081,7 +37332,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveMethodReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34150,7 +37401,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/ContraceptiveNotUsedReasonVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34274,7 +37525,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/SexualActivityVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34431,7 +37682,7 @@
           "url": "http://standardhealthrecord.org/shr/sex/vs/IntercourseDifficultyVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34525,9 +37776,9 @@
               "type": "ValueSetIncludesCodeRule"
             },
             {
-              "label": "Problem getting an erection",
+              "label": "Condition getting an erection",
               "code": {
-                "label": "Problem getting an erection",
+                "label": "Condition getting an erection",
                 "type": "code",
                 "code": "C0455842",
                 "system": "http://ncimeta.nci.nih.gov",
@@ -34577,7 +37828,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34602,7 +37853,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceCategoryVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34693,7 +37944,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceBodyPositionVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34729,7 +37980,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceComponentVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34875,7 +38126,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/SupportSurfaceFeatureVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -34966,7 +38217,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/PressureUlcerBodySiteVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35156,7 +38407,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/PressureUlcerAssociationVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35192,7 +38443,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/VisibleInternalStructureVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35294,7 +38545,7 @@
           "url": "http://standardhealthrecord.org/shr/skin/vs/WoundEdgeAppearanceVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35364,7 +38615,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/RespiratoryRateQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35533,7 +38784,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/RespiratoryRateMethodVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35614,7 +38865,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/HeartRateQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35692,7 +38943,7 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35783,7 +39034,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/OxygenSaturationBodySiteVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35852,7 +39103,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/BodyTemperatureQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -35877,7 +39128,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/BodyTemperatureBodySiteVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36012,7 +39263,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/BodyHeightQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36103,7 +39354,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/BodyWeightQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36280,7 +39531,7 @@
             }
           ],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36339,7 +39590,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureQualifierVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36430,7 +39681,7 @@
           "url": "http://standardhealthrecord.org/shr/vital/vs/BloodPressureBodySiteVS",
           "concepts": [],
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36471,7 +39722,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/actor/cs/LanguageQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36543,13 +39794,50 @@
           ]
         },
         {
+          "label": "EvidenceQualityCS",
+          "namespace": "shr.assessment",
+          "type": "CodeSystem",
+          "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty. (http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS:compelling_evidence)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+              "code": "compelling_evidence",
+              "display": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty.",
+              "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS"
+            },
+            {
+              "label": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence. (http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS:suggestive_evidence)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+              "code": "suggestive_evidence",
+              "display": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence.",
+              "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS"
+            },
+            {
+              "label": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments. (http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS:weak_evidence)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS",
+              "code": "weak_evidence",
+              "display": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments.",
+              "url": "http://standardhealthrecord.org/shr/assessment/cs/EvidenceQualityCS"
+            }
+          ]
+        },
+        {
           "label": "MissingValueReasonCS",
           "namespace": "shr.base",
           "description": "Reasons that a value associated with a test or other observation is missing.",
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/base/cs/MissingValueReasonCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36626,7 +39914,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/base/cs/GenericAnswersCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36663,7 +39951,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/ReligiousPracticeStatusCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36701,7 +39989,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/ReligiousRestrictionCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36738,7 +40026,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/SubstanceAbuseTreatmentTypeCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36839,7 +40127,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/AlcoholUseScreeningToolCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36876,7 +40164,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/SpecialDietFollowedCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -36937,7 +40225,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/DietNutritionConcernCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -37094,7 +40382,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/SleepQualityReasonCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -37195,7 +40483,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/behavior/cs/PhysicalActivityLimitationCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -37299,13 +40587,74 @@
           ]
         },
         {
+          "label": "ConditionCategoryCS",
+          "namespace": "shr.condition",
+          "type": "CodeSystem",
+          "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+          "grammarVersion": {
+            "major": 5,
+            "minor": 0,
+            "patch": 0
+          },
+          "children": [
+            {
+              "label": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury. (http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS:disease)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+              "code": "disease",
+              "display": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury.",
+              "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+            },
+            {
+              "label": "A disability experienced by the subject. (http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS:functional_impairment)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+              "code": "functional_impairment",
+              "display": "A disability experienced by the subject.",
+              "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+            },
+            {
+              "label": "An abnormality of physiologic structure. (http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS:structural_abnormality)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+              "code": "structural_abnormality",
+              "display": "An abnormality of physiologic structure.",
+              "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+            },
+            {
+              "label": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder. (http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS:concern)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+              "code": "concern",
+              "display": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder.",
+              "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+            },
+            {
+              "label": "A sign or manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears. (http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS:symptom)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+              "code": "symptom",
+              "display": "A sign or manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears.",
+              "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+            },
+            {
+              "label": "An adverse reaction to an intervention. (http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS:adverse_reaction)",
+              "type": "Concept",
+              "system": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS",
+              "code": "adverse_reaction",
+              "display": "An adverse reaction to an intervention.",
+              "url": "http://standardhealthrecord.org/shr/condition/cs/ConditionCategoryCS"
+            }
+          ]
+        },
+        {
           "label": "CodingQualifierCS",
           "namespace": "shr.core",
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/CodingQualifierCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37373,8 +40722,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/QualitativeDateTimeCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37546,8 +40895,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/SemiquantitativeDurationCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37631,8 +40980,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/SemiquantitativeFrequencyCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37748,8 +41097,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/QualitativeFrequencyCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37801,8 +41150,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/ThreeValueLogicCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37838,8 +41187,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37860,11 +41209,11 @@
               "url": "http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS"
             },
             {
-              "label": "Moderate (http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS:moderate)",
+              "label": "Moderate/Intermediate or Borderline (http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS:moderate)",
               "type": "Concept",
               "system": "http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS",
               "code": "moderate",
-              "display": "Moderate",
+              "display": "Moderate/Intermediate or Borderline",
               "url": "http://standardhealthrecord.org/shr/core/cs/QualitativeValueScaleCS"
             },
             {
@@ -37892,8 +41241,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/QualitativeLikelihoodCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37953,8 +41302,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/ThreePriorityCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -37991,8 +41340,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/SettingCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -38277,8 +41626,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/core/cs/PerformanceGradingScaleCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 1,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -38331,7 +41680,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/demographics/cs/AddressUseCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38392,7 +41741,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/demographics/cs/TelephoneTypeCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38421,7 +41770,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/demographics/cs/TelecomQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38530,7 +41879,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/demographics/cs/InsuranceProviderTypeCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38599,7 +41948,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/device/cs/RespiratoryRateSettingCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38660,7 +42009,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/device/cs/RespiratoryAssistDeviceCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38713,7 +42062,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/encounter/cs/EpisodeOfCareCompletionCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38806,7 +42155,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/encounter/cs/EncounterTypeCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38867,7 +42216,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/encounter/cs/ReferralSourceTypeCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38952,7 +42301,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/encounter/cs/TreatmentCooperationCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -38997,7 +42346,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/encounter/cs/ReasonEncounterDidNotHappenCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39042,7 +42391,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/environment/cs/ResourceStabilityCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39087,7 +42436,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/environment/cs/IncomeSourceCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39212,7 +42561,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/environment/cs/NonCashBenefitCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39305,7 +42654,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/environment/cs/AnimalExposureCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39390,7 +42739,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/environment/cs/CoinhabitantCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39459,7 +42808,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/environment/cs/HomeEnvironmentRiskCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39747,57 +43096,12 @@
           ]
         },
         {
-          "label": "RequestStatusCS",
-          "namespace": "shr.lab",
-          "type": "CodeSystem",
-          "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-          "grammarVersion": {
-            "major": 4,
-            "minor": 0,
-            "patch": 0
-          },
-          "children": [
-            {
-              "label": "The request is complete and is ready for fulfillment. (http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS:active)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-              "code": "active",
-              "display": "The request is complete and is ready for fulfillment.",
-              "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-            },
-            {
-              "label": "The request is being carried out. (http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS:in_progress)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-              "code": "in_progress",
-              "display": "The request is being carried out.",
-              "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-            },
-            {
-              "label": "The request has been held by originating system/user request. (http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS:suspended)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-              "code": "suspended",
-              "display": "The request has been held by originating system/user request.",
-              "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-            },
-            {
-              "label": "The diagnostic testing has been completed, the report(s) released, and no further work is planned. (http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS:completed)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS",
-              "code": "completed",
-              "display": "The diagnostic testing has been completed, the report(s) released, and no further work is planned.",
-              "url": "http://standardhealthrecord.org/shr/lab/cs/RequestStatusCS"
-            }
-          ]
-        },
-        {
           "label": "EducationalAttainmentCS",
           "namespace": "shr.lifehistory",
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/EducationalAttainmentCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -39890,7 +43194,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/TeratogenCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40351,7 +43655,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/EmploymentStatusCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40468,7 +43772,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/MilitaryStatusCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40505,7 +43809,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/USMilitaryBranchCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40574,7 +43878,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/MilitaryServiceDischargeStatusCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40624,11 +43928,11 @@
         {
           "label": "MilitaryServiceEraCS",
           "namespace": "shr.lifehistory",
-          "description": "Values were taken from Final HMIS Data Standards March 2010 (Homeless Management Information System), field 4.15E Veteran’s Information. See: https://www.onecpd.info/resources/documents/FinalHMISDataStandards_March2010.pdf.",
+          "description": "Values were taken from Final HMIS Data Standards March 2010 (Homeless Management Information System), field 5.05E Veteran’s Information. See: https://www.onecpd.info/resources/documents/FinalHMISDataStandards_March2010.pdf.",
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/lifehistory/cs/MilitaryServiceEraCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40705,8 +44009,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/medication/cs/ReasonMedicationNotUsedCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -40798,8 +44102,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/medication/cs/MedicationChangeTypeCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -40851,8 +44155,8 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/medication/cs/MedicationChangeReasonCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
@@ -40913,7 +44217,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/observation/cs/ExposureReasonCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -40983,7 +44287,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/observation/cs/ObservationNotMadeReasonCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41031,153 +44335,122 @@
           ]
         },
         {
-          "label": "ProblemCategoryCS",
-          "namespace": "shr.problem",
+          "label": "HER2MethodCS",
+          "namespace": "shr.oncology",
           "type": "CodeSystem",
-          "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
+          "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury. (http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS:disease)",
+              "label": "SPot-Light HER2 CISH test (http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS:spot-light)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-              "code": "disease",
-              "display": "A disorder of structure or function in a human, animal, or plant, especially one that produces specific signs or symptoms or that affects a specific location and is not simply a direct result of physical injury.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
+              "code": "spot-light",
+              "display": "SPot-Light HER2 CISH test",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS"
             },
             {
-              "label": "A disability experienced by the subject. (http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS:functional_impairment)",
+              "label": "ImmunoHistoChemistry test (http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS:ihc)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-              "code": "functional_impairment",
-              "display": "A disability experienced by the subject.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
+              "code": "ihc",
+              "display": "ImmunoHistoChemistry test",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS"
             },
             {
-              "label": "An abnormality of physiologic structure. (http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS:structural_abnormality)",
+              "label": "Inform HER2 Dual ISH test (In SituHybridization) (http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS:inform)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-              "code": "structural_abnormality",
-              "display": "An abnormality of physiologic structure.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
-            },
-            {
-              "label": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder. (http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS:concern)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-              "code": "concern",
-              "display": "Something the subject is worried about, which may or may not have yet been manifested. The object of the concern does not have to be a medical disorder.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
-            },
-            {
-              "label": "A manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears. (http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS:symptom)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-              "code": "symptom",
-              "display": "A manifestation of a deeper cause, of known or unknown etiology, e.g. pain or ringing in the ears.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
-            },
-            {
-              "label": "An adverse reaction to an intervention. (http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS:adverse_reaction)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS",
-              "code": "adverse_reaction",
-              "display": "An adverse reaction to an intervention.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/ProblemCategoryCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS",
+              "code": "inform",
+              "display": "Inform HER2 Dual ISH test (In SituHybridization)",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/HER2MethodCS"
             }
           ]
         },
         {
-          "label": "EvidenceQualityCS",
-          "namespace": "shr.problem",
+          "label": "DegreeOfLymphaticInvolvementCS",
+          "namespace": "shr.oncology",
           "type": "CodeSystem",
-          "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
+          "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty. (http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS:compelling_evidence)",
+              "label": "Only a few cancer cells are in the node. (http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS:microscopic)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
-              "code": "compelling_evidence",
-              "display": "Compelling evidence; indicates that assessments are based on high-quality information from multiple sources. High quality evidence does not imply that the assessment is a fact or certainty.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
+              "code": "microscopic",
+              "display": "Only a few cancer cells are in the node.",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS"
             },
             {
-              "label": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence. (http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS:suggestive_evidence)",
+              "label": "The cancer can be seen or felt without aid of microscopy. (http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS:gross)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
-              "code": "suggestive_evidence",
-              "display": "Suggestive evidence; indicates that assessments are based on credible and plausible information, but not of sufficient quality or corroborated sufficiently to warrant a higher level of confidence.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
+              "code": "gross",
+              "display": "The cancer can be seen or felt without aid of microscopy.",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS"
             },
             {
-              "label": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments. (http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS:weak_evidence)",
+              "label": "Cancer has pread outside the wall of the node. (http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS:extracapsular)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS",
-              "code": "weak_evidence",
-              "display": "Weak evidence, its credibility and/or plausibility is uncertain, fragmented or poorly corroborated to make solid judgments.",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/EvidenceQualityCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS",
+              "code": "extracapsular",
+              "display": "Cancer has pread outside the wall of the node.",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/DegreeOfLymphaticInvolvementCS"
             }
           ]
         },
         {
-          "label": "GradeOrStageCS",
-          "namespace": "shr.problem",
+          "label": "StagingTimeCS",
+          "namespace": "shr.oncology",
+          "description": "When staging was done, relative to treatment events.",
           "type": "CodeSystem",
-          "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
+          "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
           "grammarVersion": {
-            "major": 4,
-            "minor": 2,
+            "major": 5,
+            "minor": 0,
             "patch": 0
           },
           "children": [
             {
-              "label": "Mild (http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS:grade_1)",
+              "label": "On initial diagnosis (http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS:clinical)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-              "code": "grade_1",
-              "display": "Mild",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+              "code": "clinical",
+              "display": "On initial diagnosis",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
             },
             {
-              "label": "Moderate (http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS:grade_2)",
+              "label": "Post-operative, after resection surgery (http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS:pathologic)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-              "code": "grade_2",
-              "display": "Moderate",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+              "code": "pathologic",
+              "display": "Post-operative, after resection surgery",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
             },
             {
-              "label": "Severe (http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS:grade_3)",
+              "label": "When patient is enrolled in a clinical trial (http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS:enrollment)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-              "code": "grade_3",
-              "display": "Severe",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+              "code": "enrollment",
+              "display": "When patient is enrolled in a clinical trial",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
             },
             {
-              "label": "Life-threatening or disabling (http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS:grade_4)",
+              "label": "Upon recurrence of disease (http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS:recurrence)",
               "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-              "code": "grade_4",
-              "display": "Life-threatening or disabling",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
-            },
-            {
-              "label": "Death (http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS:grade_5)",
-              "type": "Concept",
-              "system": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS",
-              "code": "grade_5",
-              "display": "Death",
-              "url": "http://standardhealthrecord.org/shr/problem/cs/GradeOrStageCS"
+              "system": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS",
+              "code": "recurrence",
+              "display": "Upon recurrence of disease",
+              "url": "http://standardhealthrecord.org/shr/oncology/cs/StagingTimeCS"
             }
           ]
         },
@@ -41187,7 +44460,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/sex/cs/GenderIdentityCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41256,7 +44529,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/sex/cs/ContraceptiveMethodCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41413,7 +44686,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/sex/cs/ContraceptiveMethodReasonCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41466,7 +44739,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/sex/cs/ContraceptiveNotUsedReasonCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41559,7 +44832,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/skin/cs/SupportSurfaceCategoryCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41628,7 +44901,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/skin/cs/SupportSurfaceBodyPositionCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41657,7 +44930,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/skin/cs/SupportSurfaceComponentCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41766,7 +45039,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/skin/cs/SupportSurfaceFeatureCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41835,7 +45108,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/skin/cs/PressureUlcerAssociationCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41865,7 +45138,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/RespiratoryRateQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -41991,7 +45264,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/RespiratoryRateMethodCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42053,7 +45326,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/HeartRateQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42107,7 +45380,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/HeartRateMethodCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42176,7 +45449,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/BodyTemperatureQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42197,7 +45470,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/BodyHeightQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42218,7 +45491,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/BodyWeightQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42344,7 +45617,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/BloodPressureMethodCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },
@@ -42390,7 +45663,7 @@
           "type": "CodeSystem",
           "url": "http://standardhealthrecord.org/shr/vital/cs/BloodPressureQualifierCS",
           "grammarVersion": {
-            "major": 4,
+            "major": 5,
             "minor": 0,
             "patch": 0
           },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-assemble-spec",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/templates/helpers/generateBasedOnHierarchy.js
+++ b/templates/helpers/generateBasedOnHierarchy.js
@@ -54,7 +54,7 @@ module.exports.register = function (Handlebars, options, params) {
 
                     if (de.value) {
 
-                        var addValueNode = function(val) {
+                        var addValueNode = function(val, parent) {
                                 var fieldLink = getLink(val.identifier.label, val.identifier.namespace);
                                 if (currentNamespace === val.identifier.namespace) {
                                     fieldNode = {
@@ -74,15 +74,25 @@ module.exports.register = function (Handlebars, options, params) {
                                         children: []
                                     };
                                 }
-                                entryNode.children.push(fieldNode); 
+                                parent.children.push(fieldNode); 
                             }
                             
                         if (de.value.type !== "ChoiceValue") {
-                            addValueNode(de.value);
+                            addValueNode(de.value, entryNode);
                         } else {
+                            var parentLink = getLink(de.label, de.namespace);
+                            var parentNode = {
+                                name: "Value choices",
+                                link: parentLink,
+                                isDifferentNamespace: false,
+                                children: []
+                            };
+
                             _.forEach(de.value.value, function (val) {
-                                addValueNode(val);
+                                addValueNode(val, parentNode);
                             });
+
+                            entryNode.children.push(parentNode);
                         }
                     }
                     

--- a/templates/helpers/generateBasedOnHierarchy.js
+++ b/templates/helpers/generateBasedOnHierarchy.js
@@ -56,9 +56,10 @@ module.exports.register = function (Handlebars, options, params) {
 
                         var addValueNode = function(val, parent) {
                                 var fieldLink = getLink(val.identifier.label, val.identifier.namespace);
+                                var fieldName = "Value: " + val.identifier.label;
                                 if (currentNamespace === val.identifier.namespace) {
                                     fieldNode = {
-                                        name: val.identifier.label,
+                                        name: fieldName,
                                         link: fieldLink,
                                         namespace: val.identifier.namespace,
                                         isDifferentNamespace: false,
@@ -67,7 +68,7 @@ module.exports.register = function (Handlebars, options, params) {
                                 }
                                 else {
                                     fieldNode = {
-                                        name: val.identifier.label,
+                                        name: fieldName,
                                         link: fieldLink,
                                         namespace: val.identifier.namespace,
                                         isDifferentNamespace: true,
@@ -80,11 +81,8 @@ module.exports.register = function (Handlebars, options, params) {
                         if (de.value.type !== "ChoiceValue") {
                             addValueNode(de.value, entryNode);
                         } else {
-                            var parentLink = getLink(de.label, de.namespace);
                             var parentNode = {
                                 name: "Value choices",
-                                link: parentLink,
-                                isDifferentNamespace: false,
                                 children: []
                             };
 

--- a/templates/helpers/generateBasedOnHierarchy.js
+++ b/templates/helpers/generateBasedOnHierarchy.js
@@ -54,28 +54,38 @@ module.exports.register = function (Handlebars, options, params) {
 
                     if (de.value) {
 
-                        var fieldLink = getLink(de.value.identifier.label, de.value.identifier.namespace);
-
-                        if (currentNamespace === de.value.identifier.namespace) {
-                            fieldNode = {
-                                name: de.value.identifier.label,
-                                link: fieldLink,
-                                namespace: de.value.identifier.namespace,
-                                isDifferentNamespace: false,
-                                children: []
-                            };
+                        var addValueNode = function(val) {
+                                var fieldLink = getLink(val.identifier.label, val.identifier.namespace);
+                                if (currentNamespace === val.identifier.namespace) {
+                                    fieldNode = {
+                                        name: val.identifier.label,
+                                        link: fieldLink,
+                                        namespace: val.identifier.namespace,
+                                        isDifferentNamespace: false,
+                                        children: []
+                                    };
+                                }
+                                else {
+                                    fieldNode = {
+                                        name: val.identifier.label,
+                                        link: fieldLink,
+                                        namespace: val.identifier.namespace,
+                                        isDifferentNamespace: true,
+                                        children: []
+                                    };
+                                }
+                                entryNode.children.push(fieldNode); 
+                            }
+                            
+                        if (de.value.type !== "ChoiceValue") {
+                            addValueNode(de.value);
+                        } else {
+                            _.forEach(de.value.value, function (val) {
+                                addValueNode(val);
+                            });
                         }
-                        else {
-                            fieldNode = {
-                                name: de.value.identifier.label,
-                                link: fieldLink,
-                                namespace: de.value.identifier.namespace,
-                                isDifferentNamespace: true,
-                                children: []
-                            };
-                        }
-                        entryNode.children.push(fieldNode);
                     }
+                    
                     _.forEach(de.fieldList, function (field) {
 
                         var fieldListLink = getLink(field.label, field.namespace);

--- a/templates/partials/shr_basedon_constraint.hbs
+++ b/templates/partials/shr_basedon_constraint.hbs
@@ -9,6 +9,19 @@
 		{{/if}}
 	{{else}}
 		{{#eq type "ValueSetConstraint"}}
+			{{#if bindingStrength}}
+				{{#eq bindingStrength "REQUIRED"}}
+				must be 
+				{{else}}
+					{{#eq bindingStrength "PREFERRED"}}
+					should be 
+					{{else}}
+						{{#eq bindingStrength "EXAMPLE"}}
+						could be 
+						{{/eq}}
+					{{/eq}}
+				{{/eq}}
+			{{/if}}					
 			{{#if valueset}}
 				{{#if (isSHRValueSet valueset)}}
 					{{#eq (getValuesetLink valueset @root.vsetsLookup) "TBD"}}
@@ -21,7 +34,12 @@
 				{{/if}}
 			{{else}}
 			  from valueset <code>TBD</code>
-			{{/if}}								
+			{{/if}}
+			{{#if bindingStrength}}  
+				{{#eq bindingStrength "EXTENSIBLE"}}
+				(if covered)
+				{{/eq}}
+			{{/if}}					  
 		{{else}}
 			{{#eq type "IncludesCodeConstraint"}}
 				includes {{> shr_concept code}} 

--- a/templates/partials/shr_dataelement.hbs
+++ b/templates/partials/shr_dataelement.hbs
@@ -2,6 +2,10 @@
     <a class='paddedId' id="{{label}}"></a>{{label}}
 	{{#if isEntry}}
 		[<a href="/shr/base/index.html#Entry">Entry</a>]
+	{{else}}
+		{{#if isAbstract}}
+			[Abstract]
+    	{{/if}}
     {{/if}}
 </h3>
 <p>


### PR DESCRIPTION
Gruntfile:
- added check for basedOn.namespace to account for TBD basedOns that have a label but no namespace.

Handlebars generateBasedOnHierarchy:
- Fixed error on creating visual tree when Element Value is type ChoiceValue
- For EntryElement Observation, the value of the object is a set of multiple choices. Attempting to retrieve the identifier or label of the list returns a null value.
- Solution is to iteratate over list of choices and add each option as a node individually

Handlebars basedOn Constraint:
- added support for binding strength language

Handlebars dataElement:
- added support for Abstract Elements